### PR TITLE
feat(gateway): add Tpay (Poland) payment gateway

### DIFF
--- a/app/Http/Controllers/GatewayWebhookController.php
+++ b/app/Http/Controllers/GatewayWebhookController.php
@@ -289,6 +289,67 @@ class GatewayWebhookController extends Controller
         return response("OK", 200);
     }
 
+    // ========== Tpay ==========
+
+    public function tpay(Request $request)
+    {
+        $module = $this->registry->getGatewayModule("tpay");
+        if (!$module) {
+            return response("Gateway not found", 404);
+        }
+
+        $data = array_merge($request->all(), [
+            "_raw_payload"      => $request->getContent(),
+            "_signature_header" => $request->header("X-JWS-Signature", ""),
+        ]);
+
+        try {
+            $result = $module->processWebhook($data);
+        } catch (\Throwable $e) {
+            Log::error("Tpay webhook exception: " . $e->getMessage());
+            return response("FALSE", 200);
+        }
+
+        if (!($result["success"] ?? false)) {
+            Log::warning("Tpay webhook returned failure", $result);
+            return response("FALSE", 200);
+        }
+
+        $invoiceId = $result["invoice_id"] ?? null;
+        $txnId     = $result["transaction_id"] ?? null;
+
+        if ($invoiceId && $txnId) {
+            $invoice = \App\Models\Invoice::find($invoiceId);
+            if ($invoice) {
+                $this->recordTransaction($invoice, "tpay", $txnId, (float) ($result["amount"] ?? 0));
+            }
+        }
+
+        return response("TRUE", 200);
+    }
+
+    public function tpayCapture(Request $request, \App\Models\Invoice $invoice)
+    {
+        $this->authoriseInvoice($invoice);
+
+        $module = app(\App\Services\Module\ModuleRegistry::class)->getGatewayModule("tpay");
+        if (!$module) {
+            return response()->json(["success" => false, "message" => "Not configured"]);
+        }
+
+        $result = $module->capture($invoice, $invoice->amountDue(), [
+            "redirect_url" => url("/client/invoices/{$invoice->id}?payment=success"),
+            "cancel_url"   => url("/client/invoices/{$invoice->id}?payment=cancelled"),
+            "webhook_url"  => route("gateway.tpay.webhook"),
+        ]);
+
+        if (($result["redirect"] ?? false) && !empty($result["checkout_url"])) {
+            return redirect($result["checkout_url"]);
+        }
+
+        return response()->json($result);
+    }
+
     public function razorpayCapture(Request $request, \App\Models\Invoice $invoice)
     {
         $this->authoriseInvoice($invoice);

--- a/app/Providers/ModuleServiceProvider.php
+++ b/app/Providers/ModuleServiceProvider.php
@@ -63,6 +63,8 @@ class ModuleServiceProvider extends ServiceProvider
             $registry->registerGateway("mollie", \Modules\Gateways\Mollie\MollieModule::class);
             // Razorpay (India/Asia)
             $registry->registerGateway("razorpay", \Modules\Gateways\Razorpay\RazorpayModule::class);
+            // Tpay (Poland)
+            $registry->registerGateway("tpay", \Modules\Gateways\Tpay\TpayModule::class);
 
             // SSL Modules
             $registry->registerSsl('gogetssl', \Modules\Ssl\GoGetSSL\GoGetSslModule::class);

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -77,6 +77,7 @@ return [
     'payment_method.credit' => 'Credit',
     'payment_method.bank_transfer' => 'Bank Transfer',
     'payment_method.credit_debit_card' => 'Credit / Debit Card',
+    'payment_method.tpay' => 'Tpay',
     'payment_method.paypal' => 'PayPal',
     'banktransfer.account_name' => 'Account Name',
     'banktransfer.account_number' => 'Account Number',

--- a/lang/pl/messages.php
+++ b/lang/pl/messages.php
@@ -77,6 +77,7 @@ return [
     'payment_method.credit' => 'Kredyt',
     'payment_method.bank_transfer' => 'Przelew',
     'payment_method.credit_debit_card' => 'Karta kredytowa / debetowa',
+    'payment_method.tpay' => 'Tpay',
     'payment_method.paypal' => 'PayPal',
     'banktransfer.account_name' => 'Nazwa konta',
     'banktransfer.account_number' => 'Numer konta',

--- a/lang/tr/messages.php
+++ b/lang/tr/messages.php
@@ -355,4 +355,7 @@ return [
     'whois.connect_error' => 'Error: Could not connect to :server (errno=:errno: :errstr)',
     'whois.invalid_domain' => 'Invalid domain name.',
     'whois.no_server_known' => 'No WHOIS server known for .:tld. Try querying whois.iana.org manually.',
+
+    // Added by localization sync
+    'payment_method.tpay' => 'Tpay',
 ];

--- a/lang/zh/messages.php
+++ b/lang/zh/messages.php
@@ -355,4 +355,7 @@ return [
     'whois.connect_error' => '错误：无法连接 :server（errno=:errno：:errstr）',
     'whois.invalid_domain' => '域名无效。',
     'whois.no_server_known' => '没有可用于 .:tld 的 WHOIS 服务器，请尝试手动查询 whois.iana.org。',
+
+    // Added by localization sync
+    'payment_method.tpay' => 'Tpay',
 ];

--- a/modules/Gateways/Tpay/TpayModule.php
+++ b/modules/Gateways/Tpay/TpayModule.php
@@ -1,0 +1,412 @@
+<?php
+
+namespace Modules\Gateways\Tpay;
+
+use App\Contracts\GatewayModuleInterface;
+use App\Models\GatewayLog;
+use App\Models\GatewaySettings;
+use App\Models\Invoice;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class TpayModule implements GatewayModuleInterface
+{
+    public function getModuleName(): string
+    {
+        return 'Tpay';
+    }
+
+    public function isTokenised(): bool
+    {
+        return false;
+    }
+
+    public function getConfigFields(): array
+    {
+        return [
+            ['name' => 'client_id',         'label' => 'Open API Client ID',       'type' => 'text', 'required' => true],
+            ['name' => 'client_secret',     'label' => 'Open API Client Secret',   'type' => 'password', 'required' => true],
+            ['name' => 'confirmation_code', 'label' => 'Security Code (kod bezpieczeństwa)', 'type' => 'password'],
+            ['name' => 'sandbox',           'label' => 'Sandbox Mode',             'type' => 'select', 'options' => ['0' => 'Live', '1' => 'Sandbox']],
+        ];
+    }
+
+    private function getSetting(string $key): ?string
+    {
+        return GatewaySettings::where('gateway', 'tpay')->where('setting', $key)->first()?->value;
+    }
+
+    private function isSandbox(): bool
+    {
+        return $this->getSetting('sandbox') === '1';
+    }
+
+    private function getApiUrl(): string
+    {
+        return $this->isSandbox()
+            ? 'https://openapi.sandbox.tpay.com'
+            : 'https://api.tpay.com';
+    }
+
+    private function getJwsPrefix(): string
+    {
+        return $this->isSandbox()
+            ? 'https://secure.sandbox.tpay.com'
+            : 'https://secure.tpay.com';
+    }
+
+    /**
+     * Record one gateway activity in the panel's system log (admin → Logs →
+     * Gateway). Logging must never break a payment, so failures are swallowed.
+     */
+    private function logGateway(string $data, string $result = 'success'): void
+    {
+        try {
+            GatewayLog::create([
+                'gateway' => 'tpay',
+                'date' => now(),
+                'data' => $data,
+                'result' => $result,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('Tpay: failed to write gateway log: ' . $e->getMessage());
+        }
+    }
+
+    private function getAccessToken(): ?string
+    {
+        $clientId = $this->getSetting('client_id');
+        $clientSecret = $this->getSetting('client_secret');
+
+        if (!$clientId || !$clientSecret) {
+            return null;
+        }
+
+        $response = Http::asForm()->post($this->getApiUrl() . '/oauth/auth', [
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'scope' => 'write',
+        ]);
+
+        if (!$response->successful()) {
+            Log::error('Tpay: failed to obtain access token', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+            return null;
+        }
+
+        return $response->json('access_token');
+    }
+
+    public function capture(Invoice $invoice, float $amount, array $params = []): array
+    {
+        $accessToken = $this->getAccessToken();
+        if (!$accessToken) {
+            $this->logGateway("Create transaction for invoice #{$invoice->id} failed: token request failed", 'error');
+            return ['success' => false, 'message' => 'Tpay credentials not configured or token request failed.'];
+        }
+
+        $currency = strtoupper($params['currency'] ?? shop_currency_code());
+        $invoiceNum = $invoice->invoice_num ?? $invoice->id;
+        $redirectUrl = $params['redirect_url'] ?? url("/client/invoices/{$invoice->id}?payment=success");
+        $cancelUrl = $params['cancel_url'] ?? url("/client/invoices/{$invoice->id}?payment=cancelled");
+        $webhookUrl = $params['webhook_url'] ?? route('gateway.tpay.webhook');
+
+        $payerName = trim((string) $invoice->buyer('first_name') . ' ' . (string) $invoice->buyer('last_name'));
+        if ($payerName === '') {
+            $payerName = trim((string) $invoice->buyer('company_name'));
+        }
+
+        $response = Http::withToken($accessToken)
+            ->acceptJson()
+            ->post($this->getApiUrl() . '/transactions', [
+                'amount' => round($amount, 2),
+                'currency' => $currency,
+                'description' => "Invoice #{$invoiceNum}",
+                'hiddenDescription' => 'INV-' . $invoice->id . '-' . strtoupper(substr(md5(uniqid('', true)), 0, 8)),
+                'payer' => [
+                    'email' => $invoice->buyer('email') ?: null,
+                    'name' => $payerName !== '' ? $payerName : ('Customer #' . $invoice->id),
+                ],
+                'callbacks' => [
+                    'notification' => [
+                        'url' => $webhookUrl,
+                    ],
+                    'payerUrls' => [
+                        'success' => $redirectUrl,
+                        'error' => $cancelUrl,
+                    ],
+                ],
+            ]);
+
+        if (!$response->successful()) {
+            $error = $response->json('error.description', $response->json('message', 'Unknown Tpay error'));
+            Log::error('Tpay: create transaction failed', [
+                'invoice' => $invoice->id,
+                'status' => $response->status(),
+                'error' => $error,
+            ]);
+            $this->logGateway("Create transaction for invoice #{$invoice->id} failed: {$error}", 'error');
+            return ['success' => false, 'message' => "Tpay error: {$error}"];
+        }
+
+        $data = $response->json();
+
+        $this->logGateway("Transaction created for invoice #{$invoice->id}: " . ($data['transactionId'] ?? 'unknown'));
+
+        return [
+            'success' => true,
+            'transaction_id' => $data['transactionId'] ?? null,
+            'checkout_url' => $data['transactionPaymentUrl'] ?? null,
+            'redirect' => true,
+        ];
+    }
+
+    public function refund(string $transactionId, float $amount): array
+    {
+        $accessToken = $this->getAccessToken();
+        if (!$accessToken) {
+            $this->logGateway("Refund {$transactionId} failed: token request failed", 'error');
+            return ['success' => false, 'message' => 'Tpay credentials not configured.'];
+        }
+
+        $response = Http::withToken($accessToken)
+            ->acceptJson()
+            ->post($this->getApiUrl() . '/transactions/' . rawurlencode($transactionId) . '/refunds', [
+                'amount' => round($amount, 2),
+            ]);
+
+        if (!$response->successful()) {
+            $error = $response->json('error.description', $response->json('message', 'Unknown Tpay error'));
+            Log::error('Tpay: refund failed', [
+                'transaction' => $transactionId,
+                'status' => $response->status(),
+                'error' => $error,
+            ]);
+            $this->logGateway("Refund {$transactionId} failed: {$error}", 'error');
+            return ['success' => false, 'message' => "Tpay refund error: {$error}"];
+        }
+
+        $this->logGateway("Refund {$transactionId} for " . round($amount, 2) . ' processed');
+
+        return [
+            'success' => true,
+            'transaction_id' => $transactionId,
+        ];
+    }
+
+    public function getPaymentForm(Invoice $invoice): string
+    {
+        $display = money_fmt($invoice->amountDue());
+        $invoiceId = (int) $invoice->id;
+        $captureUrl = url("/gateway/tpay/capture/{$invoiceId}");
+
+        return <<<HTML
+<div class="my-3">
+    <p class="mb-2">Pay securely with Tpay (BLIK, quick transfers, cards, and more).</p>
+    <form method="POST" action="{$captureUrl}">
+        <input type="hidden" name="_token" value="" id="tpay-csrf">
+        <button type="submit" class="btn btn-primary w-100" id="tpay-pay-btn">
+            Pay {$display} with Tpay
+        </button>
+    </form>
+</div>
+<script>
+document.getElementById('tpay-csrf').value = document.querySelector('meta[name=csrf-token]')?.content ?? '';
+</script>
+HTML;
+    }
+
+    public function processWebhook(array $data): array
+    {
+        $rawPayload = $data['_raw_payload'] ?? '';
+        $sigHeader = $data['_signature_header'] ?? '';
+
+        // Tpay signs every notification; an unsigned POST must never be acted on.
+        if (!$rawPayload || !$sigHeader) {
+            Log::warning('Tpay: webhook refused - no signature to check against');
+            $this->logGateway('Webhook rejected: unsigned request', 'error');
+            return ['success' => false, 'message' => 'Unsigned webhook.'];
+        }
+
+        if (!$this->verifyJws($rawPayload, $sigHeader)) {
+            Log::warning('Tpay: webhook JWS signature verification failed');
+            $this->logGateway('Webhook rejected: invalid JWS signature', 'error');
+            return ['success' => false, 'message' => 'Invalid webhook signature.'];
+        }
+
+        parse_str($rawPayload, $notification);
+
+        $id = $notification['id'] ?? '';
+        $trId = $notification['tr_id'] ?? '';
+        $trCrc = $notification['tr_crc'] ?? '';
+        $trAmount = $notification['tr_amount'] ?? '';
+        $trPaid = $notification['tr_paid'] ?? '';
+        $trStatus = $notification['tr_status'] ?? '';
+        $md5sum = $notification['md5sum'] ?? '';
+
+        Log::info('Tpay webhook: notification received', [
+            'tr_id' => $trId,
+            'tr_status' => $trStatus,
+            'tr_crc' => $trCrc,
+            'tr_amount' => $trAmount,
+            'tr_paid' => $trPaid,
+        ]);
+
+        $code = $this->getSetting('confirmation_code') ?? '';
+        $expectedMd5 = md5($id . $trId . number_format((float) $trAmount, 2, '.', '') . $trCrc . $code);
+
+        if (!hash_equals($expectedMd5, (string) $md5sum)) {
+            Log::warning('Tpay: webhook md5 checksum verification failed', ['tr_id' => $trId]);
+            $this->logGateway("Webhook rejected: md5 checksum failed (tr_id={$trId})", 'error');
+            return ['success' => false, 'message' => 'Invalid checksum.'];
+        }
+
+        $status = strtoupper(trim((string) $trStatus));
+        if (!in_array($status, ['TRUE', 'PAID'], true)) {
+            Log::info('Tpay webhook: transaction status ignored', [
+                'tr_id' => $trId,
+                'tr_status' => $trStatus,
+            ]);
+            $this->logGateway("Notification received (tr_id={$trId}, status={$trStatus})", 'ignored');
+            return ['success' => true, 'message' => "Status ignored: {$trStatus}"];
+        }
+
+        $invoiceId = $this->parseInvoiceId((string) $trCrc);
+        $amount = (float) ($trPaid !== '' ? $trPaid : $trAmount);
+
+        Log::info('Tpay webhook: payment confirmed', [
+            'tr_id' => $trId,
+            'invoice_id' => $invoiceId,
+            'amount' => $amount,
+        ]);
+
+        $this->logGateway("Payment confirmed (tr_id={$trId}, invoice={$invoiceId}, amount={$amount})", 'success');
+
+        return [
+            'success' => true,
+            'transaction_id' => $trId,
+            'invoice_id' => $invoiceId,
+            'amount' => $amount,
+            'gateway' => 'tpay',
+        ];
+    }
+
+    /**
+     * The invoice id from a transaction CRC ("INV-123-a1b2c3d4" -> "123").
+     * The random suffix keeps hiddenDescription unique per attempt, which Tpay
+     * enforces; the invoice number is what identifies the document.
+     */
+    private function parseInvoiceId(string $crc): ?string
+    {
+        if (preg_match('/INV-(\d+)/', $crc, $matches)) {
+            return $matches[1];
+        }
+
+        return $crc !== '' ? $crc : null;
+    }
+
+    /**
+     * Verify the RFC 7515 JWS signature Tpay signs notifications with.
+     *
+     * The signature header carries a compact JWS whose header names an x5u
+     * certificate URL. That certificate is validated against Tpay's root CA
+     * before its public key is used to check the signed payload.
+     */
+    private function verifyJws(string $rawPayload, string $jws): bool
+    {
+        $parts = explode('.', $jws);
+        if (count($parts) < 3) {
+            Log::warning('Tpay: webhook JWS malformed', ['parts' => count($parts)]);
+            return false;
+        }
+
+        $headerB64 = $parts[0];
+        $signatureB64 = $parts[2];
+
+        $headerJson = base64_decode(strtr($headerB64, '-_', '+/'));
+        $header = json_decode($headerJson, true);
+        $x5u = $header['x5u'] ?? null;
+
+        if (!$x5u) {
+            Log::warning('Tpay: webhook JWS header missing x5u', ['header' => $headerJson]);
+            return false;
+        }
+
+        $prefix = $this->getJwsPrefix();
+        if (substr($x5u, 0, strlen($prefix)) !== $prefix) {
+            Log::warning('Tpay: webhook certificate URL outside expected origin', ['x5u' => $x5u]);
+            return false;
+        }
+
+        $certificate = $this->fetchUrl($x5u, 7200);
+        $rootCa = $this->fetchUrl($prefix . '/x509/tpay-jws-root.pem', 86400);
+
+        if ($certificate === null || $rootCa === null) {
+            Log::warning('Tpay: webhook certificate fetch failed', [
+                'x5u' => $x5u,
+                'cert_len' => $certificate === null ? null : strlen($certificate),
+                'root_ca_len' => $rootCa === null ? null : strlen($rootCa),
+            ]);
+            return false;
+        }
+
+        $x509Result = openssl_x509_verify($certificate, $rootCa);
+        if ($x509Result !== 1) {
+            Log::warning('Tpay: webhook certificate not signed by Tpay CA', [
+                'x5u' => $x5u,
+                'result' => $x509Result,
+            ]);
+            return false;
+        }
+
+        $publicKey = openssl_pkey_get_public($certificate);
+        if (!$publicKey) {
+            Log::warning('Tpay: webhook public key extraction failed', ['x5u' => $x5u]);
+            return false;
+        }
+
+        $payload = str_replace('=', '', strtr(base64_encode($rawPayload), '+/', '-_'));
+        $decodedSignature = base64_decode(strtr($signatureB64, '-_', '+/'));
+
+        $result = openssl_verify(
+            $headerB64 . '.' . $payload,
+            $decodedSignature,
+            $publicKey,
+            OPENSSL_ALGO_SHA256
+        );
+
+        Log::info('Tpay: webhook JWS verification result', ['result' => $result]);
+
+        return $result === 1;
+    }
+
+    private function fetchUrl(string $url, int $ttlSeconds): ?string
+    {
+        $key = 'tpay_cert_' . md5($url);
+
+        $cached = Cache::get($key);
+        if (is_string($cached)) {
+            return $cached;
+        }
+
+        try {
+            $response = Http::timeout(10)->get($url);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (!$response->successful()) {
+            return null;
+        }
+
+        $body = $response->body();
+        if ($body !== '') {
+            Cache::put($key, $body, $ttlSeconds);
+        }
+
+        return $body;
+    }
+}

--- a/modules/Gateways/Tpay/TpayModule.php
+++ b/modules/Gateways/Tpay/TpayModule.php
@@ -27,7 +27,7 @@ class TpayModule implements GatewayModuleInterface
         return [
             ['name' => 'client_id',         'label' => 'Open API Client ID',       'type' => 'text', 'required' => true],
             ['name' => 'client_secret',     'label' => 'Open API Client Secret',   'type' => 'password', 'required' => true],
-            ['name' => 'confirmation_code', 'label' => 'Security Code (kod bezpieczeństwa)', 'type' => 'password'],
+            ['name' => 'confirmation_code', 'label' => 'Security Code (kod bezpieczeństwa)', 'type' => 'password', 'required' => true],
             ['name' => 'sandbox',           'label' => 'Sandbox Mode',             'type' => 'select', 'options' => ['0' => 'Live', '1' => 'Sandbox']],
         ];
     }

--- a/modules/Gateways/Tpay/pnlcs.json
+++ b/modules/Gateways/Tpay/pnlcs.json
@@ -1,0 +1,1 @@
+{"name":"tpay","type":"gateway","version":"1.0.0","display_name":"Tpay","description":"Tpay (Poland) Open API with BLIK, quick transfers and card payments","author":{"name":"PNLCS"}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::withoutMiddleware([\Illuminate\Foundation\Http\Middleware\PreventRequestF
     Route::post('gateway/authorize/webhook', [GatewayWebhookController::class, 'authorize'])->name('gateway.authorize.webhook');
     Route::post('gateway/mollie/webhook', [GatewayWebhookController::class, 'mollie'])->name('gateway.mollie.webhook');
     Route::post('gateway/razorpay/webhook', [GatewayWebhookController::class, 'razorpay'])->name('gateway.razorpay.webhook');
+    Route::post('gateway/tpay/webhook', [GatewayWebhookController::class, 'tpay'])->name('gateway.tpay.webhook');
 });
 
 // ===== Gateway JS-SDK Capture Endpoints (authenticated, CSRF-protected) =====
@@ -44,4 +45,5 @@ Route::middleware(['web', 'auth'])->group(function () {
     Route::post('gateway/authorize/capture/{invoice}', [GatewayWebhookController::class, 'authorizeCapture'])->name('gateway.authorize.capture');
     Route::post('gateway/mollie/capture/{invoice}', [GatewayWebhookController::class, 'mollieCapture'])->name('gateway.mollie.capture');
     Route::post('gateway/razorpay/capture/{invoice}', [GatewayWebhookController::class, 'razorpayCapture'])->name('gateway.razorpay.capture');
+    Route::post('gateway/tpay/capture/{invoice}', [GatewayWebhookController::class, 'tpayCapture'])->name('gateway.tpay.capture');
 });

--- a/tests/Feature/GatewayCaptureAuthTest.php
+++ b/tests/Feature/GatewayCaptureAuthTest.php
@@ -7,7 +7,7 @@ use App\Models\User;
 /**
  * Who may start a payment against an invoice.
  *
- * The six browser-facing capture endpoints sat in a route group commented
+ * The seven browser-facing capture endpoints sat in a route group commented
  * "authenticated, CSRF-protected" that carried no auth middleware, and not one
  * of them checked whose invoice it was. Invoice ids are sequential, so anyone
  * could POST /gateway/stripe/intent/{id} for somebody else's invoice and be
@@ -45,6 +45,7 @@ $endpoints = [
     'gateway.authorize.capture',
     'gateway.mollie.capture',
     'gateway.razorpay.capture',
+    'gateway.tpay.capture',
 ];
 
 test('a stranger cannot start a payment on an invoice', function () use ($endpoints) {


### PR DESCRIPTION
Adds a Tpay payment gateway module (Poland) using the Tpay Open API.

## What's included
- \modules/Gateways/Tpay/TpayModule.php\ — redirect-based integration (BLIK, quick transfers, cards):
  - OAuth2 client-credentials token (\/oauth/auth\, \scope=write\)
  - create transaction (\POST /transactions\) + redirect to Tpay panel
  - refund (\POST /transactions/{id}/refunds\)
  - webhook processing with mandatory JWS signature verification (RFC 7515, x5u cert + Tpay root CA) and md5sum check
  - gateway activity written to the panel's system log (\gateway_logs\)
- Routes: \gateway/tpay/webhook\ and \gateway/tpay/capture/{invoice}\
- Controller methods \	pay()\ / \	payCapture()\
- Registration in \ModuleServiceProvider\ and \payment_method.tpay\ labels (en/pl)
- Auth coverage for the new capture endpoint in \GatewayCaptureAuthTest\

## Config fields
- \client_id\ / \client_secret\ (Open API keys)
- \confirmation_code\ (security code for md5sum)
- \sandbox\ (live/sandbox toggle)