### PR TITLE
fix(clients): delete login accounts when a client is deleted

### DIFF
--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -79,6 +79,15 @@ class Client extends Model
             $client->orders()->delete();
             Affiliate::where('client_id', $client->id)->delete();
             ClientNote::where('client_id', $client->id)->delete();
+
+            // Delete the login accounts that belong only to this client so
+            // they cannot sign back in. An account shared with another client
+            // is only detached from this one.
+            $client->users()->get()->each(function (User $user) use ($client) {
+                if ($user->clients()->where('clients.id', '!=', $client->id)->doesntExist()) {
+                    $user->delete();
+                }
+            });
             $client->users()->detach(); // Remove pivot entries
         });
     }


### PR DESCRIPTION
Deleting a client soft-deleted the Client and detached the user_client pivot, but left the User (login account) in place, so a deleted customer could still sign in.

This deletes the login accounts that belong only to the deleted client (accounts shared with another client are only detached).