### PR TITLE
feat(proforma): settings-driven proforma -> VAT invoice flow

### DIFF
--- a/app/Hooks/proforma.php
+++ b/app/Hooks/proforma.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Invoice;
+use App\Services\ProformaService;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * A paid proforma is not a tax document: issue the corresponding VAT invoice,
+ * then re-fire InvoicePaid for it so the KSeF hook (and any other module)
+ * sees the VAT invoice.
+ */
+add_hook('InvoicePaid', function (array $params): void {
+    $invoice = $params['invoice'] ?? null;
+
+    if (! $invoice instanceof Invoice) {
+        return;
+    }
+
+    if (($invoice->type ?? 'vat') !== 'proforma') {
+        return;
+    }
+
+    try {
+        $vat = app(ProformaService::class)->issueVatInvoice($invoice);
+
+        if ($vat) {
+            run_hook('InvoicePaid', ['invoice' => $vat, 'transactionId' => $params['transactionId'] ?? null]);
+        }
+    } catch (\Throwable $e) {
+        Log::error('Proforma: could not issue VAT invoice for #'.$invoice->id.': '.$e->getMessage());
+    }
+});

--- a/app/Http/Controllers/Admin/ClientController.php
+++ b/app/Http/Controllers/Admin/ClientController.php
@@ -110,7 +110,7 @@ class ClientController extends Controller
         // Stats always needed (shown in all tabs)
         $data['serviceCount'] = $client->services()->count();
         $data['domainCount'] = $client->domains()->count();
-        $data['invoiceCount'] = $client->invoices()->count();
+        $data['invoiceCount'] = $client->invoices()->excludeSettledProformas()->count();
         $data['ticketCount'] = $client->tickets()->count();
         $data['unpaidInvoices'] = $client->invoices()->where('status', 'unpaid')->sum('total');
 
@@ -122,7 +122,7 @@ class ClientController extends Controller
                 $data['domains'] = $client->domains()->orderBy('id', 'desc')->paginate(15);
                 break;
             case 'invoices':
-                $data['invoices'] = $client->invoices()->orderBy('id', 'desc')->paginate(15);
+                $data['invoices'] = $client->invoices()->excludeSettledProformas()->orderBy('id', 'desc')->paginate(15);
                 break;
             case 'tickets':
                 $data['tickets'] = $client->tickets()->with('department')->orderBy('id', 'desc')->paginate(15);
@@ -137,10 +137,10 @@ class ClientController extends Controller
             default: // summary
                 $data['serviceCount'] = $client->services()->count();
                 $data['domainCount'] = $client->domains()->count();
-                $data['invoiceCount'] = $client->invoices()->count();
+                $data['invoiceCount'] = $client->invoices()->excludeSettledProformas()->count();
                 $data['ticketCount'] = $client->tickets()->count();
                 $data['unpaidInvoices'] = $client->invoices()->where('status', 'unpaid')->sum('total');
-                $data['recentInvoices'] = $client->invoices()->orderBy('id', 'desc')->limit(5)->get();
+                $data['recentInvoices'] = $client->invoices()->excludeSettledProformas()->orderBy('id', 'desc')->limit(5)->get();
                 $data['recentTickets'] = $client->tickets()->with('department')->orderBy('id', 'desc')->limit(5)->get();
                 $data['recentServices'] = $client->services()->with('product')->orderBy('id', 'desc')->limit(5)->get();
                 break;

--- a/app/Http/Controllers/Admin/InvoiceController.php
+++ b/app/Http/Controllers/Admin/InvoiceController.php
@@ -37,7 +37,7 @@ class InvoiceController extends Controller
 
     public function index(Request $request): View
     {
-        $query = Invoice::with('client');
+        $query = Invoice::with('client')->excludeSettledProformas();
 
         if ($request->filled('status')) {
             $query->where('status', $request->status);
@@ -411,7 +411,7 @@ class InvoiceController extends Controller
      */
     public function exportCsv(Request $request): StreamedResponse
     {
-        $query = Invoice::with('client');
+        $query = Invoice::with('client')->excludeSettledProformas();
 
         if ($request->filled('status')) {
             $query->where('status', $request->status);

--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -80,7 +80,7 @@ class SettingController extends Controller
         'FraudLabsApiKey', 'FraudLabsEnabled',
         'MaxMindAccountId', 'MaxMindEnabled', 'MaxMindLicenseKey',
         'TwilioAccountSid', 'TwilioAuthToken', 'TwilioVerifyEnabled', 'TwilioVerifyServiceSid',
-        'ProformaEnabled', 'ProformaNumberFormat',
+        'ProformaEnabled', 'ProformaNumberFormat', 'HidePaidProformas',
         'LateFeeAmount', 'LateFeeMinDays', 'LateFeeType',
         'MailEnabled', 'MailType', 'MaintenanceMode', 'OrderFormDisplayedOn', 'PhoneNumber',
         'SMTPHost', 'SMTPPassword', 'SMTPPort', 'SMTPSecurity', 'SMTPUsername',
@@ -116,6 +116,9 @@ class SettingController extends Controller
         }
         if (! isset($data['ProformaEnabled'])) {
             $data['ProformaEnabled'] = '0';
+        }
+        if (! isset($data['HidePaidProformas'])) {
+            $data['HidePaidProformas'] = '0';
         }
 
         // The form never carries the stored mail password back, so an empty

--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -18,15 +18,27 @@ class SettingController extends Controller
     {
         $settings = Setting::where('group', 'general')->pluck('value', 'setting');
 
+        $invoiceService = app(\App\Services\InvoiceService::class);
+        $proformaFormat = trim((string) ($settings['ProformaNumberFormat'] ?? 'PRO-{year}/{month}-{num}'));
+        $proformaFormat = $proformaFormat !== '' ? $proformaFormat : 'PRO-{year}/{month}-{num}';
+        $proformaLast = \App\Models\Invoice::where('invoice_num', 'like', 'PRO-%')->orderBy('id', 'desc')->value('invoice_num');
+        $proformaSeq = 1 + (int) \App\Models\Invoice::where('invoice_num', 'like', 'PRO-%')
+            ->selectRaw('MAX(CAST(REGEXP_REPLACE(invoice_num, "^.*[^0-9]", "") AS UNSIGNED)) as seq')
+            ->value('seq');
+
         return view('admin.settings.general', [
             'settings' => $settings,
             'mailTransport' => (string) config('mail.default'),
             'languages' => Language::active()->orderBy('sort_order')->get(),
             'countries' => \App\Support\Countries::all(),
             'paymentMethods' => $this->paymentMethods(),
-            'invoicePreview' => app(\App\Services\InvoiceService::class)->generateInvoiceNumber(),
-            'invoiceNextSeq' => app(\App\Services\InvoiceService::class)->nextInvoiceSequence(),
+            'invoicePreview' => $invoiceService->generateInvoiceNumber(),
+            'invoiceNextSeq' => $invoiceService->nextInvoiceSequence(),
             'invoiceLast' => \App\Models\Invoice::where('invoice_num', '!=', '')->orderBy('id', 'desc')->value('invoice_num'),
+            'proformaEnabled' => ($settings['ProformaEnabled'] ?? '0') === '1',
+            'proformaFormat' => $proformaFormat,
+            'proformaPreview' => $invoiceService->renderInvoiceNumber($proformaFormat, $proformaSeq),
+            'proformaLast' => $proformaLast,
         ]);
     }
 
@@ -68,6 +80,7 @@ class SettingController extends Controller
         'FraudLabsApiKey', 'FraudLabsEnabled',
         'MaxMindAccountId', 'MaxMindEnabled', 'MaxMindLicenseKey',
         'TwilioAccountSid', 'TwilioAuthToken', 'TwilioVerifyEnabled', 'TwilioVerifyServiceSid',
+        'ProformaEnabled', 'ProformaNumberFormat',
         'LateFeeAmount', 'LateFeeMinDays', 'LateFeeType',
         'MailEnabled', 'MailType', 'MaintenanceMode', 'OrderFormDisplayedOn', 'PhoneNumber',
         'SMTPHost', 'SMTPPassword', 'SMTPPort', 'SMTPSecurity', 'SMTPUsername',
@@ -100,6 +113,9 @@ class SettingController extends Controller
         }
         if (! isset($data['TwilioVerifyEnabled'])) {
             $data['TwilioVerifyEnabled'] = '0';
+        }
+        if (! isset($data['ProformaEnabled'])) {
+            $data['ProformaEnabled'] = '0';
         }
 
         // The form never carries the stored mail password back, so an empty

--- a/app/Http/Controllers/Client/HomeController.php
+++ b/app/Http/Controllers/Client/HomeController.php
@@ -22,7 +22,7 @@ class HomeController extends Controller
             'domainCount' => Domain::whereIn('client_id', $clientIds)->where('status', DomainStatus::Active->value)->count(),
             'unpaidInvoices' => Invoice::whereIn('client_id', $clientIds)->outstanding()->count(),
             'openTickets' => Ticket::whereIn('client_id', $clientIds)->stillOpen()->count(),
-            'recentInvoices' => Invoice::whereIn('client_id', $clientIds)->orderBy('id', 'desc')->limit(5)->get(),
+            'recentInvoices' => Invoice::whereIn('client_id', $clientIds)->excludeSettledProformas()->orderBy('id', 'desc')->limit(5)->get(),
             'recentTickets' => Ticket::whereIn('client_id', $clientIds)->orderBy('id', 'desc')->limit(5)->get(),
             'activeServices' => Service::whereIn('client_id', $clientIds)->where('status', ServiceStatus::Active->value)->with('product')->limit(5)->get(),
         ];

--- a/app/Http/Controllers/Client/InvoiceController.php
+++ b/app/Http/Controllers/Client/InvoiceController.php
@@ -21,6 +21,7 @@ class InvoiceController extends Controller
     public function index()
     {
         $invoices = Invoice::with('items')
+            ->excludeSettledProformas()
             ->where('client_id', $this->getClientId())
             ->orderBy('id', 'desc')
             ->paginate(25);

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -29,10 +29,14 @@ class Invoice extends Model {
 
     /**
      * Hide proformas that have been settled: once paid, a proforma is replaced
-     * by its VAT invoice and should no longer show in the invoice lists.
+     * by its VAT invoice. Gated on the "hide paid proformas" setting.
      */
     public function scopeExcludeSettledProformas($query)
     {
+        if (Setting::get('HidePaidProformas', '1') !== '1') {
+            return $query;
+        }
+
         return $query->whereNot(function ($q) {
             $q->where('type', 'proforma')->where('status', InvoiceStatus::Paid->value);
         });

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 class Invoice extends Model {
     use HasFactory;
 
-    protected $fillable = ['client_id', 'invoice_num', 'date', 'due_date', 'date_paid', 'subtotal', 'credit', 'tax', 'tax2', 'total', 'tax_rate', 'tax_rate2', 'status', 'reminder_stage', 'reminder_sent_at', 'payment_method', 'pay_method_id', 'notes',
+    protected $fillable = ['client_id', 'invoice_num', 'date', 'due_date', 'date_paid', 'subtotal', 'credit', 'tax', 'tax2', 'total', 'tax_rate', 'tax_rate2', 'status', 'type', 'source_invoice_id', 'reminder_stage', 'reminder_sent_at', 'payment_method', 'pay_method_id', 'notes',
         // Buyer as it stood when the invoice was issued (issue #7). The money
         // was already frozen; these keep the document itself immutable.
         'buyer_first_name', 'buyer_last_name', 'buyer_company_name', 'buyer_email',
@@ -25,6 +25,17 @@ class Invoice extends Model {
     public function scopeOutstanding($query)
     {
         return $query->whereIn('status', ['unpaid', 'overdue', 'partially_paid']);
+    }
+
+    /**
+     * Hide proformas that have been settled: once paid, a proforma is replaced
+     * by its VAT invoice and should no longer show in the invoice lists.
+     */
+    public function scopeExcludeSettledProformas($query)
+    {
+        return $query->whereNot(function ($q) {
+            $q->where('type', 'proforma')->where('status', InvoiceStatus::Paid->value);
+        });
     }
     protected function casts(): array { return ['date' => 'date', 'due_date' => 'date', 'date_paid' => 'datetime', 'subtotal' => 'decimal:2', 'credit' => 'decimal:2', 'tax' => 'decimal:2', 'total' => 'decimal:2', 'buyer_custom_fields' => 'array']; }
 
@@ -44,6 +55,9 @@ class Invoice extends Model {
 
     public function items() { return $this->hasMany(InvoiceItem::class); }
     public function transactions() { return $this->hasMany(Transaction::class); }
+
+    /** The proforma this VAT invoice was issued from. */
+    public function sourceInvoice() { return $this->belongsTo(self::class, 'source_invoice_id'); }
 
     public function scopeUnpaid($q) { return $q->where('status', InvoiceStatus::Unpaid->value); }
     public function scopeOverdue($q) { return $q->where('status', InvoiceStatus::Overdue->value); }

--- a/app/Services/InvoiceService.php
+++ b/app/Services/InvoiceService.php
@@ -27,10 +27,12 @@ class InvoiceService
                 'client_id' => $client->id,
                 // Freeze the buyer alongside the money (issue #7)
                 ...Invoice::buyerSnapshotFrom($client),
-                'invoice_num' => $options['invoice_num'] ?? $this->generateInvoiceNumber(),
+                'invoice_num' => $options['invoice_num'] ?? $this->generateInvoiceNumber($options['type'] ?? $this->defaultType()),
                 'date' => $options['date'] ?? now()->toDateString(),
                 'due_date' => $options['due_date'] ?? now()->addDays((int) Setting::get('InvoiceDueDays', 14))->toDateString(),
                 'status' => $options['status'] ?? InvoiceStatus::Unpaid->value,
+                'type' => $options['type'] ?? $this->defaultType(),
+                'source_invoice_id' => $options['source_invoice_id'] ?? null,
                 'payment_method' => $options['payment_method'] ?? null,
                 'notes' => $options['notes'] ?? null,
                 'subtotal' => 0,
@@ -281,29 +283,53 @@ class InvoiceService
      * {num} placeholders; {num} is the next number in the series derived
      * from the last invoice stored in the database.
      */
-    public function generateInvoiceNumber(): string
+    public function generateInvoiceNumber(?string $type = null): string
     {
-        $format = (string) Setting::get('InvoiceNumberFormat', 'INV-{num}');
-        if (trim($format) === '') {
-            $format = 'INV-{num}';
+        $type = $type ?: $this->defaultType();
+        $format = $this->numberFormatFor($type);
+
+        return $this->renderInvoiceNumber($format, $this->nextInvoiceSequence($format, $type));
+    }
+
+    /**
+     * The default invoice type for new invoices: proforma when the proforma
+     * scheme is enabled, otherwise VAT.
+     */
+    public function defaultType(): string
+    {
+        return Setting::get('ProformaEnabled', '0') === '1' ? 'proforma' : 'vat';
+    }
+
+    /**
+     * The numbering format for a given invoice type.
+     */
+    public function numberFormatFor(?string $type = null): string
+    {
+        if ($type === 'proforma') {
+            $format = (string) Setting::get('ProformaNumberFormat', 'PRO-{year}/{month}-{num}');
+
+            return trim($format) !== '' ? $format : 'PRO-{year}/{month}-{num}';
         }
 
-        return $this->renderInvoiceNumber($format, $this->nextInvoiceSequence($format));
+        $format = (string) Setting::get('InvoiceNumberFormat', 'INV-{num}');
+
+        return trim($format) !== '' ? $format : 'INV-{num}';
     }
 
     /**
      * The next sequence number for previews (the highest number already
      * issued plus one).
      */
-    public function nextInvoiceSequence(?string $format = null): int
+    public function nextInvoiceSequence(?string $format = null, ?string $type = null): int
     {
-        $format ??= (string) Setting::get('InvoiceNumberFormat', 'INV-{num}');
+        $type = $type ?: $this->defaultType();
+        $format ??= $this->numberFormatFor($type);
 
         // Without {num} the number has nowhere to grow: fall back to the
         // row id, which still keeps them unique.
         $pos = strpos((string) $format, '{num}');
         if ($pos === false) {
-            return 1 + (int) Invoice::max('id');
+            return 1 + (int) Invoice::where('type', $type)->max('id');
         }
 
         // {num} last: the series continues across format changes, reading
@@ -313,7 +339,8 @@ class InvoiceService
         // run of digits. The series only grows, so nothing is ever
         // issued twice.
         if (substr((string) $format, -5) === '{num}') {
-            $query = Invoice::where('invoice_num', 'regexp', '[0-9]$')
+            $query = Invoice::where('type', $type)
+                ->where('invoice_num', 'regexp', '[0-9]$')
                 ->selectRaw('MAX(CAST(REGEXP_REPLACE(invoice_num, "^.*[^0-9]", "") AS UNSIGNED)) as seq');
 
             // Reset each year: only the numbers issued this year count,
@@ -329,12 +356,13 @@ class InvoiceService
         // which is where the digits actually sit on issued numbers.
         $prefix = substr((string) $format, 0, $pos);
         if ($prefix === '') {
-            return 1 + (int) Invoice::max('id');
+            return 1 + (int) Invoice::where('type', $type)->max('id');
         }
 
         $like = addcslashes($prefix, '%_').'%';
 
-        return 1 + (int) Invoice::where('invoice_num', 'like', $like)
+        return 1 + (int) Invoice::where('type', $type)
+            ->where('invoice_num', 'like', $like)
             ->selectRaw('MAX(CAST(SUBSTRING(invoice_num, ?) AS UNSIGNED)) as seq', [strlen($prefix) + 1])
             ->value('seq');
     }

--- a/app/Services/ProformaService.php
+++ b/app/Services/ProformaService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\InvoiceStatus;
+use App\Events\InvoiceCreated;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Issues the VAT invoice for a paid proforma.
+ *
+ * When the proforma scheme is enabled, new invoices are proformas. Paying a
+ * proforma replaces it with a VAT invoice: same items and totals, the next
+ * number in the VAT series, and a link back to the source proforma.
+ */
+class ProformaService
+{
+    /**
+     * Issue (once) the VAT invoice for a paid proforma.
+     */
+    public function issueVatInvoice(Invoice $proforma): ?Invoice
+    {
+        if (($proforma->type ?? 'vat') !== 'proforma') {
+            return null;
+        }
+
+        $existing = Invoice::where('source_invoice_id', $proforma->id)->first();
+        if ($existing) {
+            return $existing;
+        }
+
+        try {
+            $vat = DB::transaction(function () use ($proforma) {
+                $vat = Invoice::create([
+                    'client_id' => $proforma->client_id,
+                    ...Invoice::buyerSnapshotFrom($proforma->client),
+                    'invoice_num' => app(InvoiceService::class)->generateInvoiceNumber('vat'),
+                    'date' => now()->toDateString(),
+                    'due_date' => now()->toDateString(),
+                    'date_paid' => now(),
+                    'status' => InvoiceStatus::Paid->value,
+                    'type' => 'vat',
+                    'source_invoice_id' => $proforma->id,
+                    'subtotal' => $proforma->subtotal,
+                    'credit' => $proforma->credit,
+                    'tax' => $proforma->tax,
+                    'tax2' => $proforma->tax2,
+                    'total' => $proforma->total,
+                    'tax_rate' => $proforma->tax_rate,
+                    'tax_rate2' => $proforma->tax_rate2,
+                    'payment_method' => $proforma->payment_method,
+                    'notes' => $proforma->notes,
+                ]);
+
+                foreach ($proforma->items as $item) {
+                    InvoiceItem::create([
+                        'invoice_id' => $vat->id,
+                        'client_id' => $proforma->client_id,
+                        'type' => $item->type,
+                        'rel_id' => $item->rel_id,
+                        'description' => $item->description,
+                        'qty' => $item->qty,
+                        'amount' => $item->amount,
+                        'taxed' => $item->taxed,
+                        'tax_rate' => $item->tax_rate,
+                        'tax_label' => $item->tax_label,
+                        'unit' => $item->unit,
+                        'due_date' => $item->due_date,
+                    ]);
+                }
+
+                Log::info('Proforma #'.$proforma->id.' issued VAT invoice #'.$vat->id.' ('.$vat->invoice_num.')');
+
+                return $vat;
+            });
+
+            // Notify the client (with the VAT invoice PDF) — outside the
+            // transaction so listeners see committed state.
+            event(new InvoiceCreated($vat));
+
+            return $vat;
+        } catch (\Throwable $e) {
+            Log::error('Could not issue VAT invoice for proforma #'.$proforma->id.': '.$e->getMessage());
+
+            return null;
+        }
+    }
+}

--- a/database/migrations/2026_08_31_000006_add_type_and_source_to_invoices.php
+++ b/database/migrations/2026_08_31_000006_add_type_and_source_to_invoices.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->string('type', 20)->default('vat')->after('status');
+            $table->unsignedBigInteger('source_invoice_id')->nullable()->after('type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropColumn(['type', 'source_invoice_id']);
+        });
+    }
+};

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1223,6 +1223,7 @@ return [
     'invoices.gateway' => 'Gateway',
     'invoices.invoice_cancelled' => 'Invoice Cancelled',
     'invoices.invoice_date' => 'Invoice Date',
+    'invoices.source_proforma' => 'Refers to proforma',
     'invoices.invoice_details' => 'Invoice Details',
     'invoices.invoice_hash' => 'Invoice #',
     'invoices.line_items' => 'Line Items',

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -2250,6 +2250,8 @@ return [
         'general_settings' => 'General Settings',
         'homepage_builder' => 'Homepage Builder',
         'invoice_number_format' => 'Invoice numbering scheme',
+        'proforma_enabled' => 'Enable Proforma scheme',
+        'proforma_number_format' => 'Proforma numbering scheme',
         'invoice_number_last' => 'Last invoice',
         'invoice_number_preview' => 'Preview',
         'invoice_number_reset_year' => 'Reset numbering each year',

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -2253,6 +2253,7 @@ return [
         'invoice_number_format' => 'Invoice numbering scheme',
         'proforma_enabled' => 'Enable Proforma scheme',
         'proforma_number_format' => 'Proforma numbering scheme',
+        'hide_paid_proformas' => 'Hide paid proformas',
         'invoice_number_last' => 'Last invoice',
         'invoice_number_preview' => 'Preview',
         'invoice_number_reset_year' => 'Reset numbering each year',

--- a/lang/pl/admin.php
+++ b/lang/pl/admin.php
@@ -1228,6 +1228,7 @@ return [
     'invoices.gateway' => 'Bramka',
     'invoices.invoice_cancelled' => 'Faktura anulowana',
     'invoices.invoice_date' => 'Data faktury',
+    'invoices.source_proforma' => 'Dotyczy proformy',
     'invoices.invoice_details' => 'Szczegóły faktury',
     'invoices.invoice_hash' => 'Faktura #',
     'invoices.line_items' => 'Pozycje',

--- a/lang/pl/admin.php
+++ b/lang/pl/admin.php
@@ -2257,6 +2257,7 @@ return [
         'invoice_number_format' => 'Schemat numeracji faktur',
         'proforma_enabled' => 'Włącz schemat proform',
         'proforma_number_format' => 'Schemat numeracji proform',
+        'hide_paid_proformas' => 'Nie pokazuj opłaconych proform',
         'invoice_number_last' => 'Ostatnia faktura',
         'invoice_number_preview' => 'Podgląd',
         'invoice_number_reset_year' => 'Resetuj numerację co roku',

--- a/lang/pl/admin.php
+++ b/lang/pl/admin.php
@@ -2254,6 +2254,8 @@ return [
         'general_settings' => 'Ustawienia ogólne',
         'homepage_builder' => 'Kreator strony głównej',
         'invoice_number_format' => 'Schemat numeracji faktur',
+        'proforma_enabled' => 'Włącz schemat proform',
+        'proforma_number_format' => 'Schemat numeracji proform',
         'invoice_number_last' => 'Ostatnia faktura',
         'invoice_number_preview' => 'Podgląd',
         'invoice_number_reset_year' => 'Resetuj numerację co roku',

--- a/lang/tr/admin.php
+++ b/lang/tr/admin.php
@@ -2207,7 +2207,9 @@ return [
     'services.status_hint_cancelled' => 'Hizmet iptal edildi',
     'services.delete_hint' => 'Hizmeti müşteriden ayır ve kalıcı olarak sil',
     'settings' => [
-        'admin_login_prefix' => 'Yönetici Günlükin URL Prefix',
+        'proforma_number_format' => 'Proforma numaralandırma düzeni',
+        'proforma_enabled' => 'Proforma düzeni etkinleştir',
+        'admin_login_prefix' => 'Yonetici Gunlukin URL Prefix',
         'appearance' => 'Appearance',
         'appearance_settings' => 'Appearance Ayarlatings',
         'change_password' => 'Şifreyi değiştir',

--- a/lang/zh/admin.php
+++ b/lang/zh/admin.php
@@ -2207,6 +2207,8 @@ return [
     'services.status_hint_cancelled' => '服务已取消',
     'services.delete_hint' => '将服务与客户解除关联并永久删除',
     'settings' => [
+        'proforma_number_format' => '形式发票编号方案',
+        'proforma_enabled' => '启用形式发票方案',
         'admin_login_prefix' => '管理员登录 URL 前缀',
         'appearance' => '外观',
         'appearance_settings' => '外观设置',

--- a/modules/Reports/IncomeByProductReport.php
+++ b/modules/Reports/IncomeByProductReport.php
@@ -21,6 +21,7 @@ class IncomeByProductReport extends AbstractReport
             ->leftJoin("products", "products.id", "=", "services.product_id")
             ->selectRaw("COALESCE(products.name, invoice_items.description) as product, COUNT(DISTINCT invoices.id) as invoices, SUM(invoice_items.amount) as revenue")
             ->where("invoices.status", "paid")
+            ->where("invoices.type", "!=", "proforma")
             ->whereBetween("invoices.date_paid", [$from, $to.' 23:59:59'])
             ->groupBy("product")->orderBy("revenue", "desc")->get();
         return ["columns" => ["Product", "Invoices", "Revenue"], "rows" => $rows->toArray(), "totals" => ["Total", $rows->sum("invoices"), $rows->sum("revenue")]];

--- a/modules/Reports/SalesTaxLiabilityReport.php
+++ b/modules/Reports/SalesTaxLiabilityReport.php
@@ -17,7 +17,7 @@ class SalesTaxLiabilityReport extends AbstractReport
         [$from, $to] = $this->getDateRange($request);
         $rows = DB::table("invoices")
             ->selectRaw("DATE_FORMAT(date_paid, '%Y-%m') as month, SUM(subtotal) as subtotal, SUM(tax) as tax, SUM(tax2) as tax2, SUM(total) as total")
-            ->where("status", "paid")->whereBetween("date_paid", [$from, $to.' 23:59:59'])
+            ->where("status", "paid")->where("type", "!=", "proforma")->whereBetween("date_paid", [$from, $to.' 23:59:59'])
             ->groupBy("month")->orderBy("month", "desc")->get();
         return ["columns" => ["Month", "Subtotal", "Tax", "Tax 2", "Total"], "rows" => $rows->toArray(), "totals" => ["Total", $rows->sum("subtotal"), $rows->sum("tax"), $rows->sum("tax2"), $rows->sum("total")]];
     }

--- a/resources/views/admin/invoices/show.blade.php
+++ b/resources/views/admin/invoices/show.blade.php
@@ -228,6 +228,9 @@
             <div class="panel-body">
                 <table style="width:100%;font-size:13px;border-collapse:collapse;">
                     <tr><td style="padding:4px 0;color:#777;width:45%;">{{ __('admin.invoices.invoice_hash') }}</td><td style="padding:4px 0;font-family:monospace;font-weight:600;">{{ $invoice->invoice_num }}</td></tr>
+                    @if($invoice->sourceInvoice)
+                    <tr><td style="padding:4px 0;color:#777;">{{ __('admin.invoices.source_proforma') }}</td><td style="padding:4px 0;"><a href="{{ route('admin.invoices.show', $invoice->sourceInvoice) }}" style="color:#337ab7;font-family:monospace;">{{ $invoice->sourceInvoice->invoice_num }}</a></td></tr>
+                    @endif
                     <tr><td style="padding:4px 0;color:#777;">{{ __('admin.invoices.date') }}</td><td style="padding:4px 0;">{{ $invoice->date?->format(date_fmt()) }}</td></tr>
                     <tr><td style="padding:4px 0;color:#777;">{{ __('admin.invoices.due_date') }}</td><td style="padding:4px 0;{{ ($invoice->due_date?->isPast() && $st !== 'paid') ? 'color:#d9534f;font-weight:600;' : '' }}">{{ $invoice->due_date?->format(date_fmt()) }}</td></tr>
                     @if($invoice->payment_method)

--- a/resources/views/admin/settings/general.blade.php
+++ b/resources/views/admin/settings/general.blade.php
@@ -240,6 +240,10 @@
                         <code style="background:#f5f5f5;padding:1px 5px;border-radius:3px;font-weight:600;">{{ $proformaPreview }}</code>
                     </div>
                 </div>
+                <label style="font-size:13px;display:flex;align-items:center;gap:6px;cursor:pointer;margin-top:10px;">
+                    <input type="checkbox" name="HidePaidProformas" value="1" {{ ($settings['HidePaidProformas'] ?? '1') == '1' ? 'checked' : '' }}>
+                    {{ __('admin.settings.hide_paid_proformas') }}
+                </label>
             </div>
         </div>
     </div>

--- a/resources/views/admin/settings/general.blade.php
+++ b/resources/views/admin/settings/general.blade.php
@@ -225,6 +225,22 @@
                 <span style="margin-left:14px;">{{ __('admin.settings.invoice_number_preview') }}:</span>
                 <code id="invoice-number-preview" style="background:#f5f5f5;padding:1px 5px;border-radius:3px;font-weight:600;">{{ $invoicePreview }}</code>
             </div>
+            <label style="font-size:13px;display:flex;align-items:center;gap:6px;cursor:pointer;margin-top:14px;font-weight:600;">
+                <input type="checkbox" id="proforma-enabled" name="ProformaEnabled" value="1" onchange="document.getElementById('proforma-scheme').style.display = this.checked ? '' : 'none';" {{ $proformaEnabled ? 'checked' : '' }}>
+                {{ __('admin.settings.proforma_enabled') }}
+            </label>
+            <div id="proforma-scheme" style="{{ $proformaEnabled ? '' : 'display:none;' }}">
+                <div class="form-group" style="margin-top:10px;max-width:50%;">
+                    <label class="form-label" for="proforma-number-format">{{ __('admin.settings.proforma_number_format') }}</label>
+                    <input type="text" id="proforma-number-format" name="ProformaNumberFormat" value="{{ $proformaFormat }}" class="form-control" placeholder="PRO-{year}/{month}-{num}">
+                    <div style="font-size:13px;color:#555;margin-top:6px;">
+                        <span>{{ __('admin.settings.invoice_number_last') }}:</span>
+                        <code style="background:#f5f5f5;padding:1px 5px;border-radius:3px;">{{ $proformaLast ?? '—' }}</code>
+                        <span style="margin-left:14px;">{{ __('admin.settings.invoice_number_preview') }}:</span>
+                        <code style="background:#f5f5f5;padding:1px 5px;border-radius:3px;font-weight:600;">{{ $proformaPreview }}</code>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/resources/views/client/invoices/show.blade.php
+++ b/resources/views/client/invoices/show.blade.php
@@ -11,6 +11,9 @@
     <div>
         <h1 class="pn-page-title">{{ __('client.invoices.invoice_prefix', ['id' => $invoice->invoice_num ?? $invoice->id]) }}</h1>
         <p class="pn-page-subtitle">{{ __('client.invoices.issued') }} {{ $invoice->date?->format(date_fmt()) ?? "N/A" }}</p>
+        @if($invoice->sourceInvoice)
+        <p class="pn-page-subtitle" style="color:var(--muted);">{{ __('admin.invoices.source_proforma') }}: <strong>{{ $invoice->sourceInvoice->invoice_num }}</strong></p>
+        @endif
     </div>
     <a href="{{ route('client.invoices.pdf', $invoice) }}" class="pn-btn" style="background:var(--primary);color:#fff;padding:6px 14px;border-radius:6px;text-decoration:none;font-size:13px;margin-right:8px;">{{ __('client.invoices.download_pdf') }}</a>
     <span class="badge badge-{{ strtolower($invoice->status) }}" style="font-size:13px;padding:5px 14px">{{ invoice_status_label($invoice->status) }}</span>

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -55,6 +55,9 @@
         <div class="header-right">
             <div class="invoice-title">{{ __('pdf.invoice') }}</div>
             <div class="invoice-number">#{{ $invoice->invoice_num ?? $invoice->id }}</div>
+            @if($invoice->sourceInvoice)
+            <div style="font-size:11px;color:#777;margin-top:4px;">{{ __('admin.invoices.source_proforma') }}: {{ $invoice->sourceInvoice->invoice_num }}</div>
+            @endif
             <div style="margin-top: 10px;">
                 @php
                     $statusClass = match(strtolower($invoice->status)) {


### PR DESCRIPTION
## What

Settings-driven proforma → VAT invoice flow (core feature, not an addon).

- \	ype\/\source_invoice_id\ columns on invoices.
- \ProformaService\ auto-issues a VAT invoice once a proforma is paid.
- Settings: Enable Proforma scheme, Proforma numbering scheme, Hide paid proformas.
- Settles and hides paid proformas; \excludeSettledProformas\ scope across admin/client lists.
- Income reports exclude proformas.
- \pp/Hooks/proforma.php\ re-fires \InvoicePaid\ for the generated VAT invoice.

## Notes

- Independent of KSeF (#20) and Company Lookup (#19) — no addon code touched.