### PR TITLE
fix(i18n): dedupe funds.amount_range, align zh/tr placeholders, theme token

### DIFF
--- a/lang/en/client.php
+++ b/lang/en/client.php
@@ -450,7 +450,6 @@ return [
     'form.optional' => 'optional',
     'funds' => [
         'add_amount' => 'Amount to Add',
-        'amount_range' => 'Minimum $5.00 · Maximum $10,000.00',
         'available_credit_desc' => 'Available to use on invoices and orders',
         'current_balance' => 'Current Balance',
         'current_credit' => 'Current Account Credit',

--- a/lang/pl/client.php
+++ b/lang/pl/client.php
@@ -450,7 +450,6 @@ return [
     'form.optional' => 'opcjonalnie',
     'funds' => [
         'add_amount' => 'Kwota doładowania',
-        'amount_range' => 'Minimum $5.00 · Maksimum $10 000.00',
         'available_credit_desc' => 'Dostępne do wykorzystania na fakturach i zamówieniach',
         'current_balance' => 'Aktualne saldo',
         'current_credit' => 'Aktualne saldo konta',

--- a/lang/tr/client.php
+++ b/lang/tr/client.php
@@ -449,7 +449,6 @@ return [
     'form.optional' => 'optional',
     'funds' => [
         'add_amount' => 'Tutar to Ekle',
-        'amount_range' => 'Minimum $5.00, maximum $10,000.00',
         'available_credit_desc' => 'Available for invoices and purchases.',
         'current_balance' => 'Mevcut Bakiye',
         'current_credit' => 'Current Credit Balance',
@@ -463,7 +462,7 @@ return [
         'subtitle' => 'Add credit to your account for future purchases.',
         'title' => 'Add Funds',
     ],
-    'funds.amount_range' => 'Minimum $5.00, maximum $10,000.00',
+    'funds.amount_range' => 'Minimum :min, maksimum :max',
     'funds.available_credit_desc' => 'Available for invoices and purchases.',
     'funds.bank_transfer' => 'Bank Transfer',
     'funds.current_credit' => 'Current Credit Balance',

--- a/lang/zh/client.php
+++ b/lang/zh/client.php
@@ -449,7 +449,6 @@ return [
     'form.optional' => '可选',
     'funds' => [
         'add_amount' => '充值金额',
-        'amount_range' => '最低 5.00 美元 · 最高 10,000.00 美元',
         'available_credit_desc' => '可用于支付发票和订单。',
         'current_balance' => '当前余额',
         'current_credit' => '当前账户余额',
@@ -463,7 +462,7 @@ return [
         'subtitle' => '为账户余额充值。',
         'title' => '充值',
     ],
-    'funds.amount_range' => '最低 5.00 美元 · 最高 10,000.00 美元',
+    'funds.amount_range' => '最低 :min · 最高 :max',
     'funds.available_credit_desc' => '可用于支付发票和订单。',
     'funds.bank_transfer' => '银行转账',
     'funds.current_credit' => '当前账户余额',

--- a/resources/views/client/invoices/show.blade.php
+++ b/resources/views/client/invoices/show.blade.php
@@ -139,7 +139,7 @@
             @elseif($gw === "stripe")
                 <div class="gw-form-box">
                     <p class="text-muted text-sm mb-16">{{ __('client.invoices.stripe_desc') }}</p>
-                    <div id="stripe-card-element" style="border:1.5px solid var(--border);padding:12px;border-radius:var(--radius-sm);background:#fff;margin-bottom:16px">
+                    <div id="stripe-card-element" style="border:1.5px solid var(--border);padding:12px;border-radius:var(--radius-sm);background:var(--bg);margin-bottom:16px">
                         <em style="color:var(--muted);font-size:13px">{{ __('client.invoices.stripe_placeholder') }}</em>
                     </div>
                     <button type="button" onclick="stripePayNow({{ $invoice->id }})" class="btn btn-primary">


### PR DESCRIPTION
## What

- Remove the dead nested \unds.amount_range\ copy (the flat \unds.amount_range\ with \:min\/\:max\ is authoritative) in en/pl/tr/zh.
- Align zh/tr flat \unds.amount_range\ to use \:min\/\:max\ placeholders.
- Replace hardcoded \ackground:#fff\ on the Stripe card element with \ar(--bg)\.

## Why

Fixes the translation duplicate-key and Simplified Chinese parity failures, plus the client theme-token audit.