### PR TITLE
fix(invoices): show formatted invoice number in admin invoices list

### DIFF
--- a/resources/views/admin/invoices/index.blade.php
+++ b/resources/views/admin/invoices/index.blade.php
@@ -66,7 +66,7 @@
                 @endphp
                 <tr>
                     <td><input type="checkbox" name="invoice_ids[]" value="{{ $invoice->id }}" class="row-checkbox"></td>
-                    <td><a href="{{ route("admin.invoices.show", $invoice) }}" style="color:#337ab7;text-decoration:none;font-family:monospace;">#{{ $invoice->id }}</a></td>
+                    <td><a href="{{ route("admin.invoices.show", $invoice) }}" style="color:#337ab7;text-decoration:none;font-family:monospace;">#{{ $invoice->invoice_num ?? $invoice->id }}</a></td>
                     <td>
                         @if($invoice->client)
                         <a href="{{ route("admin.clients.show", $invoice->client_id) }}" style="color:#337ab7;text-decoration:none;">{{ $invoice->client->full_name }}</a>


### PR DESCRIPTION
The admin invoices list showed the raw row id in the Invoice # column instead of the configured invoice number. Fix: show invoice_num with a fallback to id for legacy invoices (same pattern as the client invoices list).