### PR TITLE
fix(addons): drop whole-cache flush on addon settings save

### DIFF
--- a/app/Http/Controllers/Admin/AddonController.php
+++ b/app/Http/Controllers/Admin/AddonController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Services\AddonManager;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 
 class AddonController extends Controller
 {
@@ -77,10 +76,6 @@ class AddonController extends Controller
         }
 
         $this->manager->saveSettings($name, $settings);
-
-        // Addon settings feed behaviour; drop derived caches so a change takes
-        // effect immediately rather than after the TTL lapses.
-        Cache::flush();
 
         return back()->with('success', __('messages.success.settings_updated'));
     }


### PR DESCRIPTION
## Opis

Odpowiedź na uwagę w review #21: \AddonController::saveSettings()\ wywoływało \Cache::flush()\, czyszcząc cały cache aplikacji przy każdym zapisie ustawień dodatku.

## Zmiana

- Usuwa \Cache::flush()\ i nieużywany import \Illuminate\Support\Facades\Cache\.

## Uzasadnienie

Dodatki (CompanyLookup, KSeF, OpenBRIS, CEIDG) nie cache'ują ustawień ani odpowiedzi — odczytują bezpośrednio przez \AddonSetting::getForAddon()/getSetting()\ z DB. \cache_ttl\ z konfiguracji dodatku istnieje jako deklaratywny parametr, ale nigdzie nie jest używane. W tej sytuacji nie ma konkretnego klucza do celowego \Cache::forget()\, a flush całego cache to czysta strata (kasuje niepowiązane cache na obciążonym panelu) bez żadnej korzyści — dlatego zamiast \orget()\ usuwam wywołanie w całości.