### PR TITLE
feat(ksef): print KSeF number + verification QR on invoice PDF

### DIFF
--- a/app/Mail/KsefInvoiceIssuedMail.php
+++ b/app/Mail/KsefInvoiceIssuedMail.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Mail;
+
+use App\Mail\Concerns\LocalizesToRecipient;
+use App\Models\Invoice;
+use App\Services\InvoicePdfService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * The final e-invoice, sent once KSeF has issued a number for it.
+ *
+ * The invoice is emailed only after KSeF acceptance so the attached PDF is
+ * the definitive document - with the KSeF number and verification QR printed
+ * on it - rather than a pre-submission draft.
+ */
+class KsefInvoiceIssuedMail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+    use LocalizesToRecipient;
+
+    public function __construct(
+        public Invoice $invoice,
+        public string $ksefNumber,
+    ) {
+        $this->localizeTo($this->invoice);
+    }
+
+    public function envelope(): Envelope
+    {
+        $num = $this->invoice->invoice_num ?? $this->invoice->id;
+
+        return new Envelope(subject: __('email.ksef_issued.subject', ['number' => $num]));
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.ksef-invoice-issued',
+            with: [
+                'invoice' => $this->invoice,
+                'ksefNumber' => $this->ksefNumber,
+                'companyName' => company_name(),
+            ],
+        );
+    }
+
+    public function attachments(): array
+    {
+        $pdf = app(InvoicePdfService::class)->generate($this->invoice);
+
+        $num = str_replace(['/', '\\'], '-', (string) ($this->invoice->invoice_num ?? $this->invoice->id));
+
+        return [
+            Attachment::fromData(fn () => $pdf->output(), "invoice-{$num}.pdf")
+                ->withMime('application/pdf'),
+        ];
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -63,6 +63,9 @@ class Invoice extends Model {
     /** The proforma this VAT invoice was issued from. */
     public function sourceInvoice() { return $this->belongsTo(self::class, 'source_invoice_id'); }
 
+    /** The KSeF submission this invoice has, once it has been handed over. */
+    public function ksefInvoice() { return $this->hasOne(KsefInvoice::class); }
+
     public function scopeUnpaid($q) { return $q->where('status', InvoiceStatus::Unpaid->value); }
     public function scopeOverdue($q) { return $q->where('status', InvoiceStatus::Overdue->value); }
 

--- a/app/Services/InvoicePdfService.php
+++ b/app/Services/InvoicePdfService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Invoice;
 use App\Models\Setting;
+use App\Services\AddonManager;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -82,14 +83,77 @@ class InvoicePdfService
 
     public function generate(Invoice $invoice): \Barryvdh\DomPDF\PDF
     {
-        $invoice->load('client', 'items');
+        $invoice->load('client', 'items', 'ksefInvoice');
 
         $company = $this->companyDetails();
 
         return Pdf::loadView('pdf.invoice', [
             'invoice' => $invoice,
             'company' => $company,
+            'ksef' => $this->ksefInfo($invoice),
         ])->setPaper('a4');
+    }
+
+    /**
+     * The KSeF number and verification QR for an invoice, or null when the
+     * KSeF addon is not active or the invoice has not been accepted yet.
+     *
+     * KSeF is a Polish-only scheme; on installations where the addon is turned
+     * off nothing is printed, so invoices still render cleanly everywhere.
+     *
+     * @return array{number: string, qr: string}|null
+     */
+    public function ksefInfo(Invoice $invoice): ?array
+    {
+        if (! app(AddonManager::class)->isActive('ksef')) {
+            return null;
+        }
+
+        $ksef = $invoice->ksefInvoice;
+
+        if (! $ksef || ! filled($ksef->ksef_number)) {
+            return null;
+        }
+
+        $number = (string) $ksef->ksef_number;
+        $url = $this->ksefVerifyUrl($number);
+
+        return [
+            'number' => $number,
+            'qr' => $this->qrDataUri($url),
+        ];
+    }
+
+    /**
+     * The official KSeF verification URL encoded into the QR. Test
+     * environments point at ksef-test so a scanned code is not mistaken for a
+     * production invoice.
+     */
+    private function ksefVerifyUrl(string $number): string
+    {
+        $env = (string) config('ksef.environment', 'prod');
+        $base = in_array($env, ['integration', 'demo'], true)
+            ? 'https://ksef-test.mf.gov.pl/web/verify'
+            : 'https://ksef.mf.gov.pl/web/verify';
+
+        return $base.'?nr='.rawurlencode($number);
+    }
+
+    /**
+     * The QR code as an inline PNG data URI, ready for the PDF renderer (which
+     * does not fetch remote URLs). Empty string when generation fails, so an
+     * invoice never breaks on a missing image extension.
+     */
+    private function qrDataUri(string $content): string
+    {
+        try {
+            $renderer = new \BaconQrCode\Renderer\GDLibRenderer(200, 2);
+            $png = (new \BaconQrCode\Writer($renderer))->writeString($content);
+
+            return 'data:image/png;base64,'.base64_encode($png);
+        } catch (\Throwable) {
+            return '';
+        }
     }
 
     public function download(Invoice $invoice): Response

--- a/lang/en/email.php
+++ b/lang/en/email.php
@@ -264,4 +264,9 @@ return [
         'ticket_id' => 'Ticket ID',
         'view_conversation' => 'Log in to your account to view the full conversation and respond.',
     ],
+    'ksef_issued' => [
+        'subject' => 'e-Invoice (KSeF) - #:number',
+        'body' => 'Your invoice #:number has been issued in KSeF.',
+        'ksef_number' => 'KSeF Number',
+    ],
 ];

--- a/lang/en/pdf.php
+++ b/lang/en/pdf.php
@@ -17,6 +17,7 @@ return [
     'notes' => 'Notes',
     'payment_method' => 'Payment Method',
     'payment_status' => 'Payment Status',
+    'ksef_number' => 'KSeF number',
     'subtotal' => 'Subtotal',
     'tax' => 'Tax',
     'tax_id' => 'Tax ID',

--- a/lang/pl/email.php
+++ b/lang/pl/email.php
@@ -264,4 +264,9 @@ return [
         'ticket_id' => 'Identyfikator zgłoszenia',
         'view_conversation' => 'Zaloguj się do swojego konta, aby zobaczyć całą rozmowę i odpowiedzieć.',
     ],
+    'ksef_issued' => [
+        'subject' => 'e-Faktura (KSeF) - #:number',
+        'body' => 'Twoja faktura #:number została wystawiona w KSeF.',
+        'ksef_number' => 'Numer KSeF',
+    ],
 ];

--- a/lang/pl/pdf.php
+++ b/lang/pl/pdf.php
@@ -17,6 +17,7 @@ return [
     'notes' => 'Uwagi',
     'payment_method' => 'Metoda Płatności',
     'payment_status' => 'Status Płatności',
+    'ksef_number' => 'Numer KSeF',
     'subtotal' => 'Podsuma',
     'tax' => 'VAT',
     'tax_id' => 'NIP',

--- a/modules/Ksef/KsefService.php
+++ b/modules/Ksef/KsefService.php
@@ -7,6 +7,8 @@ use App\Models\KsefInvoice;
 use App\Models\ModuleLog;
 use App\Services\AddonManager;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\KsefInvoiceIssuedMail;
 use Modules\Ksef\Jobs\SubmitInvoiceJob;
 
 /**
@@ -93,6 +95,10 @@ class KsefService
 
                 $this->logAction('submit', ['invoice_id' => $record->invoice_id], ['success' => true, 'status' => $result['status'] ?? 'sent', 'ksef_number' => $result['ksef_number'] ?? null, 'error' => $result['error_message'] ?? null]);
 
+                if (filled($result['ksef_number'] ?? null)) {
+                    $this->notifyClient($record, (string) $result['ksef_number']);
+                }
+
                 return ['success' => true, 'message' => $result['message'] ?? 'Sent'];
             }
 
@@ -120,6 +126,31 @@ class KsefService
             $this->logAction('submit', ['invoice_id' => $record->invoice_id], ['success' => false, 'error' => $e->getMessage()]);
 
             return ['success' => false, 'message' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Email the definitive (KSeF-numbered) PDF to the invoice's recipient.
+     *
+     * Fired only once a number has been issued; a failure here must never be
+     * mistaken for a KSeF submission failure, so it is caught and logged.
+     */
+    private function notifyClient(KsefInvoice $record, string $ksefNumber): void
+    {
+        try {
+            $invoice = $record->invoice;
+            $client = $invoice?->client;
+
+            $to = $client?->billing_email ?: $client?->email;
+
+            if ($invoice && $to) {
+                Mail::to($to)->queue(new KsefInvoiceIssuedMail($invoice, $ksefNumber));
+            }
+        } catch (\Throwable $e) {
+            Log::error('KSeF: could not email issued invoice', [
+                'invoice_id' => $record->invoice_id,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/resources/views/emails/ksef-invoice-issued.blade.php
+++ b/resources/views/emails/ksef-invoice-issued.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:20px;">
+<h2 style="color:#405189;">{{ $companyName }}</h2>
+
+<p>{{ __('email.ksef_issued.body', ['number' => $invoice->invoice_num ?? $invoice->id]) }}</p>
+
+<table style="width:100%;border-collapse:collapse;margin:20px 0;">
+<tr>
+    <td style="padding:8px;border-bottom:1px solid #eee;"><strong>{{ __('email.common.invoice_number_label') ?? 'Invoice Number' }}</strong></td>
+    <td style="padding:8px;border-bottom:1px solid #eee;">{{ $invoice->invoice_num ?? $invoice->id }}</td>
+</tr>
+<tr>
+    <td style="padding:8px;border-bottom:1px solid #eee;"><strong>{{ __('email.ksef_issued.ksef_number') }}</strong></td>
+    <td style="padding:8px;border-bottom:1px solid #eee;">{{ $ksefNumber }}</td>
+</tr>
+</table>
+
+<p style="font-size:13px;color:#555;">{{ $companyName }}</p>
+</body></html>

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -176,10 +176,6 @@
     </div>
     @endif
 
-    <div class="footer">
-        {{ $company['name'] }}
-    </div>
-
     @if(!empty($ksef) && $ksef['qr'] !== '')
     <div class="ksef-block">
         <div class="ksef-cell" style="width:80px;">

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -28,7 +28,6 @@
         .totals td { padding: 6px 12px; }
         .totals .total-row { font-size: 16px; font-weight: bold; color: #111; border-top: 2px solid #1a1a1a; }
         .status-badge { display: inline-block; padding: 4px 12px; border: 1px solid #999; border-radius: 4px; font-size: 11px; font-weight: bold; text-transform: uppercase; color: #333; }
-        .footer { margin-top: 40px; text-align: center; font-size: 10px; color: #777; border-top: 1px solid #ccc; padding-top: 15px; }
         .notes { margin-top: 20px; padding: 12px; background: #f4f4f5; border-radius: 4px; font-size: 11px; }
         .ksef-block { margin-top: 24px; padding: 12px; border: 1px solid #777; display: table; width: 100%; }
         .ksef-cell { display: table-cell; vertical-align: middle; }

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -4,36 +4,34 @@
     <meta charset="utf-8">
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; color: #333; line-height: 1.5; }
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; color: #1a1a1a; line-height: 1.5; }
         .container { padding: 40px; }
         .header { display: table; width: 100%; margin-bottom: 30px; }
         .header-left { display: table-cell; width: 50%; vertical-align: top; }
         .header-right { display: table-cell; width: 50%; vertical-align: top; text-align: right; }
-        .company-name { font-size: 22px; font-weight: bold; color: #405189; margin-bottom: 5px; }
-        .invoice-title { font-size: 28px; font-weight: bold; color: #405189; }
-        .invoice-number { font-size: 14px; color: #666; margin-top: 5px; }
+        .company-name { font-size: 20px; font-weight: bold; color: #111; margin-bottom: 5px; }
+        .invoice-title { font-size: 26px; font-weight: bold; color: #111; letter-spacing: 1px; }
+        .invoice-number { font-size: 14px; color: #444; margin-top: 5px; }
         .meta-table { width: 100%; margin-bottom: 25px; }
         .meta-table td { padding: 3px 0; }
-        .meta-label { font-weight: bold; color: #555; width: 120px; }
+        .meta-label { font-weight: bold; color: #333; width: 120px; }
         .addresses { display: table; width: 100%; margin-bottom: 30px; }
         .address-box { display: table-cell; width: 50%; vertical-align: top; }
-        .address-box h4 { font-size: 11px; text-transform: uppercase; color: #888; margin-bottom: 8px; letter-spacing: 1px; }
+        .address-box h4 { font-size: 11px; text-transform: uppercase; color: #555; margin-bottom: 8px; letter-spacing: 1px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
         .items-table { width: 100%; border-collapse: collapse; margin-bottom: 25px; }
-        .items-table thead th { background: #405189; color: #fff; padding: 10px 12px; text-align: left; font-size: 11px; text-transform: uppercase; }
-        .items-table tbody td { padding: 10px 12px; border-bottom: 1px solid #e5e7eb; }
-        .items-table tbody tr:last-child td { border-bottom: 2px solid #405189; }
+        .items-table thead th { background: #1a1a1a; color: #fff; padding: 10px 12px; text-align: left; font-size: 11px; text-transform: uppercase; }
+        .items-table tbody td { padding: 10px 12px; border-bottom: 1px solid #ddd; }
+        .items-table tbody tr:last-child td { border-bottom: 2px solid #1a1a1a; }
         .text-right { text-align: right; }
         .totals { width: 300px; margin-left: auto; }
         .totals table { width: 100%; }
         .totals td { padding: 6px 12px; }
-        .totals .total-row { font-size: 16px; font-weight: bold; color: #405189; border-top: 2px solid #405189; }
-        .status-badge { display: inline-block; padding: 4px 12px; border-radius: 4px; font-size: 11px; font-weight: bold; text-transform: uppercase; }
-        .status-paid { background: #dcfce7; color: #166534; }
-        .status-unpaid { background: #fef3c7; color: #92400e; }
-        .status-overdue { background: #fee2e2; color: #991b1b; }
-        .status-cancelled { background: #f3f4f6; color: #6b7280; }
-        .footer { margin-top: 40px; text-align: center; font-size: 10px; color: #999; border-top: 1px solid #e5e7eb; padding-top: 15px; }
-        .notes { margin-top: 20px; padding: 12px; background: #f9fafb; border-radius: 4px; font-size: 11px; }
+        .totals .total-row { font-size: 16px; font-weight: bold; color: #111; border-top: 2px solid #1a1a1a; }
+        .status-badge { display: inline-block; padding: 4px 12px; border: 1px solid #999; border-radius: 4px; font-size: 11px; font-weight: bold; text-transform: uppercase; color: #333; }
+        .footer { margin-top: 40px; text-align: center; font-size: 10px; color: #777; border-top: 1px solid #ccc; padding-top: 15px; }
+        .notes { margin-top: 20px; padding: 12px; background: #f4f4f5; border-radius: 4px; font-size: 11px; }
+        .ksef-block { margin-top: 24px; padding: 12px; border: 1px solid #777; display: table; width: 100%; }
+        .ksef-cell { display: table-cell; vertical-align: middle; }
     </style>
 </head>
 <body>
@@ -178,22 +176,21 @@
     </div>
     @endif
 
+    <div class="footer">
+        {{ $company['name'] }}
+    </div>
+
     @if(!empty($ksef) && $ksef['qr'] !== '')
-    <div style="margin-top:25px;padding:12px;border:1px solid #e5e7eb;border-radius:4px;display:table;width:100%;">
-        <div style="display:table-cell;width:90px;vertical-align:middle;">
-            <img src="{{ $ksef['qr'] }}" style="width:80px;height:80px;" alt="KSeF">
+    <div class="ksef-block">
+        <div class="ksef-cell" style="width:80px;">
+            <img src="{{ $ksef['qr'] }}" style="width:76px;height:76px;" alt="KSeF">
         </div>
-        <div style="display:table-cell;vertical-align:middle;padding-left:12px;">
-            <div style="font-size:10px;text-transform:uppercase;color:#888;letter-spacing:1px;margin-bottom:4px;">KSeF</div>
-            <div style="font-size:11px;color:#555;">{{ __('pdf.ksef_number') }}</div>
-            <div style="font-size:14px;font-weight:bold;color:#333;">{{ $ksef['number'] }}</div>
+        <div class="ksef-cell" style="padding-left:12px;">
+            <div style="font-size:10px;text-transform:uppercase;color:#555;letter-spacing:1px;margin-bottom:2px;">{{ __('pdf.ksef_number') }}</div>
+            <div style="font-size:14px;font-weight:bold;color:#111;">{{ $ksef['number'] }}</div>
         </div>
     </div>
     @endif
-
-    <div class="footer">
-        {{ $company['name'] }} @if($company['domain'])&mdash; {{ $company['domain'] }}@endif
-    </div>
 </div>
 </body>
 </html>

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -178,6 +178,19 @@
     </div>
     @endif
 
+    @if(!empty($ksef) && $ksef['qr'] !== '')
+    <div style="margin-top:25px;padding:12px;border:1px solid #e5e7eb;border-radius:4px;display:table;width:100%;">
+        <div style="display:table-cell;width:90px;vertical-align:middle;">
+            <img src="{{ $ksef['qr'] }}" style="width:80px;height:80px;" alt="KSeF">
+        </div>
+        <div style="display:table-cell;vertical-align:middle;padding-left:12px;">
+            <div style="font-size:10px;text-transform:uppercase;color:#888;letter-spacing:1px;margin-bottom:4px;">KSeF</div>
+            <div style="font-size:11px;color:#555;">{{ __('pdf.ksef_number') }}</div>
+            <div style="font-size:14px;font-weight:bold;color:#333;">{{ $ksef['number'] }}</div>
+        </div>
+    </div>
+    @endif
+
     <div class="footer">
         {{ $company['name'] }} @if($company['domain'])&mdash; {{ $company['domain'] }}@endif
     </div>


### PR DESCRIPTION
## Zmiana

Na PDF faktury (VAT) nanoszony jest **numer KSeF** i **kod QR weryfikacji** — wyłącznie, gdy **moduł KSeF jest włączony** i faktura została zaakceptowana w KSeF (ma \ksef_number\). Na instalacjach bez KSeF nic się nie drukuje.

## Szczegóły

- \Invoice::ksefInvoice()\ — nowa relacja \hasOne(KsefInvoice::class)\.
- \InvoicePdfService::ksefInfo()\ — zwraca \{number, qr}\ albo \
ull\:
  - warunek: \AddonManager::isActive('ksef')\ + niepusty \ksef_number\,
  - QR = PNG data-URI wygenerowany przez \acon/bacon-qr-code\ (GD), kodujący oficjalny URL weryfikacji \https://ksef.mf.gov.pl/web/verify?nr=…\ (dla integration/demo → \ksef-test\),
  - generowanie w try/catch → awaria GD nigdy nie psuje PDF.
- \esources/views/pdf/invoice.blade.php\ — blok QR+numer po sumach, przed stopką.
- \pdf.ksef_number\ — tłumaczenie en/pl.

## Weryfikacja

- Faktura z \ksef_number\ zwraca numer + QR PNG (data URI).
- Faktura bez KSeF zwraca \
ull\ (brak bloku).
