### PR TITLE
fix(pdf): remove company name + domain from invoice footer

### DIFF
--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -177,10 +177,6 @@
         {{ $invoice->notes }}
     </div>
     @endif
-
-    <div class="footer">
-        {{ $company['name'] }} @if($company['domain'])&mdash; {{ $company['domain'] }}@endif
-    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Usuwa stopkę faktury PDF zawierającą nazwę firmy oraz odsyłacz do domeny (\{{company}} — domain\). Faktura kończy się na notatkach/totalach (a po wdrożeniu KSeF — na bloku numeru KSeF).