### PR TITLE
fix(clients): default new-client form to configured preferences

### DIFF
--- a/app/Http/Controllers/Admin/ClientController.php
+++ b/app/Http/Controllers/Admin/ClientController.php
@@ -56,7 +56,11 @@ class ClientController extends Controller
         $defaultPaymentMethod = Setting::get('DefaultPaymentMethod', 'banktransfer');
         $languages = \App\Models\Language::getActiveLanguages();
 
-        return view('admin.clients.create', compact('groups', 'currencies', 'customFields', 'paymentMethods', 'defaultPaymentMethod', 'languages'));
+        $defaultCountry = Setting::get('Country', 'PL');
+        $defaultLanguage = Setting::get('DefaultLanguage', config('app.locale', 'en'));
+        $defaultPhonePrefix = \App\Support\Countries::phonePrefix($defaultCountry);
+
+        return view('admin.clients.create', compact('groups', 'currencies', 'customFields', 'paymentMethods', 'defaultPaymentMethod', 'languages', 'defaultCountry', 'defaultLanguage', 'defaultPhonePrefix'));
     }
 
     public function store(Request $request)

--- a/resources/views/admin/clients/create.blade.php
+++ b/resources/views/admin/clients/create.blade.php
@@ -33,7 +33,7 @@
                 <div class="form-group"><label class="form-label">{{ __('common.form.country') }}</label>
                     <select name="country" id="country" class="form-control">
                         @foreach(\App\Support\Countries::all() as $code => $name)
-                        <option value="{{ $code }}" {{ old('country', 'US') == $code ? 'selected' : '' }}>{{ $name }}</option>
+                            <option value="{{ $code }}" {{ old('country', $defaultCountry ?? '') == $code ? 'selected' : '' }}>{{ $name }}</option>
                         @endforeach
                     </select>
                 </div>
@@ -41,7 +41,7 @@
                     <div style="display:flex;gap:6px;">
                         <select name="phone_prefix" id="phone_prefix" class="form-control" style="width:90px !important;flex-shrink:0;">
                             @foreach(\App\Support\Countries::PHONE_PREFIXES as $code => $prefix)
-                            <option value="{{ $prefix }}" {{ old('phone_prefix') == $prefix ? 'selected' : '' }}>{{ $code }} {{ $prefix }}</option>
+                            <option value="{{ $prefix }}" {{ old('phone_prefix', $defaultPhonePrefix ?? '') == $prefix ? 'selected' : '' }}>{{ $code }} {{ $prefix }}</option>
                             @endforeach
                         </select>
                         <input type="text" name="phone_number" value="{{ old('phone_number') }}" class="form-control" style="flex:1;min-width:0;">
@@ -53,7 +53,7 @@
                 <div class="form-group"><label class="form-label">{{ __('common.form.language') }}</label>
                     <select name="language" class="form-control">
                         @foreach($languages ?? [] as $lang)
-                        <option value="{{ $lang->code }}">{{ $lang->native_name ?? $lang->name }} ({{ $lang->code }})</option>
+                            <option value="{{ $lang->code }}" {{ old('language', $defaultLanguage ?? '') == $lang->code ? 'selected' : '' }}>{{ $lang->native_name ?? $lang->name }} ({{ $lang->code }})</option>
                         @endforeach
                     </select>
                 </div>


### PR DESCRIPTION
Formularz dodawania klienta (dmin/clients/create) ignorował domyślne ustawienia i twardo używał USA/języka pierwszego z listy.\n\nTeraz pola są domyślnie ustawiane z ustawień:\n- **Kraj** — \Setting Country\ (poprzednio twardo \US\)\n- **Prefiks telefonu** — wyliczony z kraju (\Countries::phonePrefix\)\n- **Język** — \Setting DefaultLanguage\\n- **Domyślny sposób płatności** — już działał (\DefaultPaymentMethod\)\n\nWeryfikacja serwera: Country=PL, DefaultLanguage=pl, DefaultPaymentMethod=tpay.