### PR TITLE
feat(ksef): KSeF status under Billing menu (addon-gated)

### DIFF
--- a/app/Listeners/SendNotificationListener.php
+++ b/app/Listeners/SendNotificationListener.php
@@ -22,6 +22,7 @@ use App\Mail\TicketOpenedMail;
 use App\Mail\TicketReplyMail;
 use App\Models\Setting;
 use App\Models\Ticket;
+use App\Services\AddonManager;
 use App\Services\NotificationService;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -68,13 +69,22 @@ class SendNotificationListener
 
     public function handleInvoiceCreated(InvoiceCreated $event): void
     {
-        try {
-            $email = $event->invoice->client?->billingEmail();
-            if ($email) {
-                Mail::to($email)->queue(new InvoiceCreatedMail($event->invoice));
+        // When KSeF is active, a VAT invoice is emailed once its KSeF number
+        // is assigned (KsefInvoiceIssuedMail, with the QR-verified PDF). The
+        // un-numbered PDF sent here would be a duplicate, so skip it.
+        // Proformas are never submitted to KSeF and keep the normal email.
+        $ksefActive = app(AddonManager::class)->isActive('ksef');
+        $isVat = ($event->invoice->type ?? 'vat') === 'vat';
+
+        if (! ($isVat && $ksefActive)) {
+            try {
+                $email = $event->invoice->client?->billingEmail();
+                if ($email) {
+                    Mail::to($email)->queue(new InvoiceCreatedMail($event->invoice));
+                }
+            } catch (\Throwable $e) {
+                Log::error('SendNotification: InvoiceCreated email failed', ['error' => $e->getMessage()]);
             }
-        } catch (\Throwable $e) {
-            Log::error('SendNotification: InvoiceCreated email failed', ['error' => $e->getMessage()]);
         }
 
         $this->dispatchNotification('invoice.created', [

--- a/app/Providers/ViewServiceProvider.php
+++ b/app/Providers/ViewServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Models\TicketDepartment;
+use App\Services\AddonManager;
 use App\View\Composers\LanguageComposer;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\View;
@@ -38,6 +39,9 @@ class ViewServiceProvider extends ServiceProvider
             // The sidebar ticket-search form needs the department list; it used
             // to render an empty select posting a parameter nothing read.
             $view->with('sidebarDepartments', TicketDepartment::orderBy('name')->get(['id', 'name']));
+
+            // Whether the KSeF addon is enabled — gates the billing-menu entry.
+            $view->with('ksefActive', app(AddonManager::class)->isActive('ksef'));
         });
 
         View::composer([

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -10,6 +10,7 @@ return [
     'add_new' => 'Add New',
     'addon_modules.activate' => 'Activate',
     'addon_modules.author' => 'Author',
+    'addon_modules.changelog' => 'Changelog',
     'addon_modules.deactivate' => 'Deactivate',
     'addon_modules.description' => 'Extend PNLCS with extensions. Activate, configure, and manage.',
     'addon_modules.no_modules' => 'No extensions found in modules/Addons/ directory.',

--- a/lang/en/admin.php
+++ b/lang/en/admin.php
@@ -1623,6 +1623,7 @@ return [
     'nav.fraud' => 'Fraud',
     'nav.general_settings' => 'General Settings',
     'nav.invoices' => 'Invoices',
+    'nav.ksef_status' => 'KSeF Status',
     'nav.knowledge_base' => 'Knowledge Base',
     'nav.languages' => 'Languages',
     'nav.list_all_orders' => 'List All Orders',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -436,7 +436,7 @@ return [
     'company_lookup.bank_accounts' => 'Bank accounts',
     'company_lookup.pkd' => 'PKD',
     'company_lookup.error' => 'The lookup failed. Please try again.',
-    'company_lookup.settings_title' => 'Company Lookup (NIP)',
+    'company_lookup.settings_title' => 'Company Lookup (PL)',
     'company_lookup.settings_saved' => 'Company lookup settings saved.',
     'company_lookup.settings_hint' => 'Registry credentials for the GUS/MF company lookup. The GUS API key is stored encrypted and never leaves the backend.',
     'company_lookup.gus_api_key' => 'GUS BIR API key',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -418,6 +418,7 @@ return [
     'ksef.test_ok' => 'Connection to the KSeF API works.',
     'ksef.auth_failed' => 'KSeF authentication failed — check the NIP and key.',
     'ksef.addon_output_hint' => 'Paid invoices are handed to KSeF automatically. Below is the submission status.',
+    'ksef.addon_moved_hint' => 'The KSeF submission status is now shown under Billing → KSeF status.',
     'ksef.queued' => 'The invoice has been queued for KSeF submission.',
     'company_lookup.gus_unavailable' => 'Could not fetch data from the GUS register.',
     'company_lookup.mf_unavailable' => 'Could not fetch data from the VAT white list (MF).',

--- a/lang/pl/admin.php
+++ b/lang/pl/admin.php
@@ -1628,6 +1628,7 @@ return [
     'nav.fraud' => 'Oszustwa',
     'nav.general_settings' => 'Ustawienia ogólne',
     'nav.invoices' => 'Faktury',
+    'nav.ksef_status' => 'KSeF status',
     'nav.knowledge_base' => 'Baza wiedzy',
     'nav.languages' => 'Języki',
     'nav.list_all_orders' => 'Wyświetl wszystkie zamówienia',

--- a/lang/pl/admin.php
+++ b/lang/pl/admin.php
@@ -10,6 +10,7 @@ return [
     'add_new' => 'Dodaj nowy',
     'addon_modules.activate' => 'Aktywuj',
     'addon_modules.author' => 'Autor',
+    'addon_modules.changelog' => 'Dziennik zmian',
     'addon_modules.deactivate' => 'Dezaktywuj',
     'addon_modules.description' => 'Rozszerz PNLCS o rozszerzenia. Aktywuj, konfiguruj i zarządzaj.',
     'addon_modules.no_modules' => 'Nie znaleziono rozszerzeń w katalogu modules/Addons/.',

--- a/lang/pl/messages.php
+++ b/lang/pl/messages.php
@@ -418,6 +418,7 @@ return [
     'ksef.test_ok' => 'Połączenie z API KSeF działa.',
     'ksef.auth_failed' => 'Uwierzytelnienie w KSeF nie powiodło się — sprawdź NIP i klucz.',
     'ksef.addon_output_hint' => 'Opłacone faktury są automatycznie przekazywane do KSeF. Poniżej status wysyłek.',
+    'ksef.addon_moved_hint' => 'Status wysyłek do KSeF jest teraz dostępny pod Rozliczenia → KSeF status.',
     'ksef.queued' => 'Faktura została zakolejkowana do wysyłki do KSeF.',
     'company_lookup.gus_unavailable' => 'Nie udało się pobrać danych z rejestru GUS.',
     'company_lookup.mf_unavailable' => 'Nie udało się pobrać danych z Białej Listy VAT (MF).',

--- a/lang/pl/messages.php
+++ b/lang/pl/messages.php
@@ -436,7 +436,7 @@ return [
     'company_lookup.bank_accounts' => 'Rachunki bankowe',
     'company_lookup.pkd' => 'PKD',
     'company_lookup.error' => 'Wyszukiwanie nie powiodło się. Spróbuj ponownie.',
-    'company_lookup.settings_title' => 'Wyszukiwanie firmy (NIP)',
+    'company_lookup.settings_title' => 'Wyszukiwanie firmy PL',
     'company_lookup.settings_saved' => 'Ustawienia wyszukiwania firmy zapisane.',
     'company_lookup.settings_hint' => 'Poświadczenia rejestrów GUS/MF dla wyszukiwania firmy po NIP. Klucz API GUS jest przechowywany szyfrowanie i nigdy nie opuszcza backendu.',
     'company_lookup.gus_api_key' => 'Klucz API GUS BIR',

--- a/modules/Addons/CompanyLookup/CompanyLookupModule.php
+++ b/modules/Addons/CompanyLookup/CompanyLookupModule.php
@@ -22,9 +22,35 @@ class CompanyLookupModule implements AddonModuleInterface
 
     public function getDescription(): string { return __('messages.company_lookup.addon_description'); }
 
-    public function getVersion(): string { return '1.0.0'; }
+    public function getVersion(): string { return '1.1.0'; }
 
     public function getAuthor(): string { return 'PNLCS'; }
+
+    /**
+     * Version history shown on the module page, newest first.
+     *
+     * @return array<int, array{version:string, date:string, changes:list<string>}>
+     */
+    public function changelog(): array
+    {
+        return [
+            [
+                'version' => '1.1.0',
+                'date' => '2026-09-05',
+                'changes' => [
+                    'GUS provider migrated to the BIR1.1 API (new endpoint, SOAP 1.2 + WS-Addressing).',
+                    'Result parsing fixed via html_entity_decode.',
+                ],
+            ],
+            [
+                'version' => '1.0.0',
+                'date' => '2026-09-01',
+                'changes' => [
+                    'Initial release. NIP lookups against GUS, MF (VAT white list), CEIDG and OpenBRIS.',
+                ],
+            ],
+        ];
+    }
 
     public function activate(): array
     {

--- a/modules/Addons/Ksef/KsefModule.php
+++ b/modules/Addons/Ksef/KsefModule.php
@@ -3,16 +3,15 @@
 namespace Modules\Addons\Ksef;
 
 use App\Contracts\AddonModuleInterface;
-use App\Models\KsefInvoice;
 use Illuminate\Http\Request;
 use Modules\Ksef\KsefSettings;
 
 /**
  * KSeF (Krajowy System e-Faktur) addon.
  *
- * Paid invoices are handed to the Polish national e-invoicing system; the
- * addon screen lists what has been sent, its acceptance state and offers a
- * retry for failed submissions and a correction marker.
+ * Paid invoices are handed to the Polish national e-invoicing system. The
+ * submission status list lives in its own screen under Billing → KSeF status
+ * (`admin.ksef.index`), shown only while this addon is active.
  */
 class KsefModule implements AddonModuleInterface
 {
@@ -53,97 +52,9 @@ class KsefModule implements AddonModuleInterface
 
     public function output(Request $request): string
     {
-        $html = '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">'
-            .'<p style="font-size:13px;color:var(--pn-muted);margin:0;">'.__('messages.ksef.addon_output_hint').'</p>'
-            .'<form method="POST" action="'.route('admin.ksef.test').'" style="margin:0;">'
-            .'<input type="hidden" name="_token" value="'.csrf_token().'">'
-            .'<button type="submit" class="btn btn-success btn-sm" style="font-size:13px;padding:6px 14px;font-weight:600;">'.__('messages.ksef.test').'</button>'
-            .'</form>'
-            .'</div>';
-
-        $records = KsefInvoice::with(['invoice.client', 'correction'])
-            ->orderByDesc('id')
-            ->paginate(20);
-
-        if ($records->isEmpty()) {
-            return $html.'<p style="color:var(--pn-muted);font-size:13px;">'.__('messages.ksef.none_yet').'</p>';
-        }
-
-        $html .= '<table style="width:100%;font-size:13px;border-collapse:collapse;">';
-        $html .= '<tr>'
-            .'<th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.invoice').'</th>'
-            .'<th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.client').'</th>'
-            .'<th style="padding:8px;text-align:right;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.total').'</th>'
-            .'<th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.status').'</th>'
-            .'<th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.ksef_number').'</th>'
-            .'<th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.sent_at').'</th>'
-            .'<th style="padding:8px;text-align:right;color:var(--pn-muted);border-bottom:1px solid var(--border);">'.__('messages.ksef.actions').'</th>'
-            .'</tr>';
-
-        foreach ($records as $r) {
-            $status = $this->statusBadge($r->status);
-            $actions = $this->actions($r);
-
-            $invoiceLink = $r->invoice
-                ? '<a href="'.route('admin.invoices.show', $r->invoice).'" style="color:#337ab7;">#'.e($r->invoice->invoice_num ?? $r->invoice->id).'</a>'
-                : '—';
-            $client = $r->invoice?->client?->display_name ?? '—';
-            $total = $r->invoice ? money_fmt($r->invoice->total) : '—';
-
-            $html .= '<tr>'
-                .'<td style="padding:8px;">'.$invoiceLink.'</td>'
-                .'<td style="padding:8px;">'.e($client).'</td>'
-                .'<td style="padding:8px;text-align:right;">'.$total.'</td>'
-                .'<td style="padding:8px;">'.$status.'</td>'
-                .'<td style="padding:8px;">'.e($r->ksef_number ?? '—').'</td>'
-                .'<td style="padding:8px;">'.($r->sent_at ? $r->sent_at->format(date_fmt().' H:i') : '—').'</td>'
-                .'<td style="padding:8px;text-align:right;white-space:nowrap;">'.$actions.'</td>'
-                .'</tr>';
-
-            if ($r->error_message) {
-                $html .= '<tr><td colspan="7" style="padding:0 8px 8px;color:#c43c35;font-size:12px;">'.e($r->error_message).'</td></tr>';
-            }
-        }
-
-        $html .= '</table>';
-        $html .= $records->links();
-
-        return $html;
-    }
-
-    protected function statusBadge(string $status): string
-    {
-        $map = [
-            'pending' => ['label' => __('messages.ksef.status_pending'), 'color' => '#f59e0b'],
-            'sent' => ['label' => __('messages.ksef.status_sent'), 'color' => '#337ab7'],
-            'accepted' => ['label' => __('messages.ksef.status_accepted'), 'color' => '#46a546'],
-            'rejected' => ['label' => __('messages.ksef.status_rejected'), 'color' => '#c43c35'],
-            'error' => ['label' => __('messages.ksef.status_error'), 'color' => '#c43c35'],
-            'corrected' => ['label' => __('messages.ksef.status_corrected'), 'color' => '#6c757d'],
-        ];
-        $m = $map[$status] ?? ['label' => $status, 'color' => '#6c757d'];
-
-        return '<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:'.$m['color'].'1a;color:'.$m['color'].';font-weight:600;font-size:12px;">'.e($m['label']).'</span>';
-    }
-
-    protected function actions(KsefInvoice $r): string
-    {
-        $html = '';
-
-        if (in_array($r->status, ['pending', 'error', 'rejected'], true)) {
-            $html .= '<form method="POST" action="'.route('admin.ksef.resend', $r).'" style="display:inline;margin:0;">'
-                .'<input type="hidden" name="_token" value="'.csrf_token().'">'
-                .'<button type="submit" class="btn btn-sm btn-outline" style="font-size:12px;padding:3px 10px;">'.__('messages.ksef.resend').'</button>'
-                .'</form> ';
-        }
-
-        if (in_array($r->status, ['sent', 'accepted'], true)) {
-            $html .= '<form method="POST" action="'.route('admin.ksef.mark-corrected', $r).'" style="display:inline;margin:0;" onsubmit="return confirm(\''.__('messages.ksef.confirm_corrected').'\');">'
-                .'<input type="hidden" name="_token" value="'.csrf_token().'">'
-                .'<button type="submit" class="btn btn-sm btn-outline" style="font-size:12px;padding:3px 10px;">'.__('messages.ksef.mark_corrected').'</button>'
-                .'</form>';
-        }
-
-        return $html ?: '—';
+        return '<p style="font-size:13px;color:var(--pn-muted);margin:0;">'.__('messages.ksef.addon_moved_hint').'</p>'
+            .'<p style="margin-top:12px;">'
+            .'<a href="'.route('admin.ksef.index').'" class="btn btn-primary btn-sm" style="font-size:13px;">'.__('admin.nav.ksef_status').'</a>'
+            .'</p>';
     }
 }

--- a/modules/Addons/Ksef/KsefModule.php
+++ b/modules/Addons/Ksef/KsefModule.php
@@ -21,9 +21,36 @@ class KsefModule implements AddonModuleInterface
 
     public function getDescription(): string { return __('messages.ksef.addon_description'); }
 
-    public function getVersion(): string { return '1.0.0'; }
+    public function getVersion(): string { return '1.1.0'; }
 
     public function getAuthor(): string { return 'PNLCS'; }
+
+    /**
+     * Version history shown on the module page, newest first.
+     *
+     * @return array<int, array{version:string, date:string, changes:list<string>}>
+     */
+    public function changelog(): array
+    {
+        return [
+            [
+                'version' => '1.1.0',
+                'date' => '2026-09-07',
+                'changes' => [
+                    'Submission status moved to a dedicated screen under Billing → KSeF status.',
+                    'Final e-invoice PDF (with KSeF number + verification QR) emailed once issued.',
+                    'Connection test button on the module page.',
+                ],
+            ],
+            [
+                'version' => '1.0.0',
+                'date' => '2026-09-03',
+                'changes' => [
+                    'Initial release. Hands paid invoices to KSeF with retry and correction actions.',
+                ],
+            ],
+        ];
+    }
 
     public function activate(): array
     {
@@ -52,9 +79,14 @@ class KsefModule implements AddonModuleInterface
 
     public function output(Request $request): string
     {
-        return '<p style="font-size:13px;color:var(--pn-muted);margin:0;">'.__('messages.ksef.addon_moved_hint').'</p>'
-            .'<p style="margin-top:12px;">'
-            .'<a href="'.route('admin.ksef.index').'" class="btn btn-primary btn-sm" style="font-size:13px;">'.__('admin.nav.ksef_status').'</a>'
-            .'</p>';
+        $test = '<form method="POST" action="'.route('admin.ksef.test').'" style="display:inline;margin:0;">'
+            .'<input type="hidden" name="_token" value="'.csrf_token().'">'
+            .'<button type="submit" class="btn btn-success btn-sm" style="font-size:13px;padding:6px 14px;font-weight:600;">'.__('messages.ksef.test').'</button>'
+            .'</form>';
+
+        $link = '<a href="'.route('admin.ksef.index').'" class="btn btn-primary btn-sm" style="font-size:13px;">'.__('admin.nav.ksef_status').'</a>';
+
+        return '<p style="display:flex;gap:8px;align-items:center;margin:0;">'.$test.' '.$link.'</p>'
+            .'<p style="font-size:13px;color:var(--pn-muted);margin:10px 0 0;">'.__('messages.ksef.addon_moved_hint').'</p>';
     }
 }

--- a/modules/Ksef/Http/Admin/KsefController.php
+++ b/modules/Ksef/Http/Admin/KsefController.php
@@ -16,6 +16,18 @@ class KsefController extends Controller
     ) {}
 
     /**
+     * The submission status list, shown under Billing → KSeF status.
+     */
+    public function index()
+    {
+        $records = KsefInvoice::with(['invoice.client', 'correction'])
+            ->orderByDesc('id')
+            ->paginate(20);
+
+        return view('admin.ksef.index', ['records' => $records]);
+    }
+
+    /**
      * Test the connection to the KSeF API.
      */
     public function test()

--- a/modules/Ksef/routes.php
+++ b/modules/Ksef/routes.php
@@ -7,6 +7,7 @@ Route::middleware(['web', 'admin.auth', 'admin.2fa', 'admin.permission:manage_pr
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {
+        Route::get('ksef', [KsefController::class, 'index'])->name('ksef.index');
         Route::post('ksef/test', [KsefController::class, 'test'])->name('ksef.test');
         Route::post('ksef/invoices/{record}/resend', [KsefController::class, 'resend'])->name('ksef.resend');
         Route::post('ksef/invoices/{record}/mark-corrected', [KsefController::class, 'markCorrected'])->name('ksef.mark-corrected');

--- a/resources/views/admin/config/addon-output.blade.php
+++ b/resources/views/admin/config/addon-output.blade.php
@@ -61,4 +61,28 @@
 </div>
 @endif
 
+@php($changelog = method_exists($addon, 'changelog') ? $addon->changelog() : [])
+@if(!empty($changelog))
+<div class="card" style="margin-top:16px;">
+    <div class="card-header"><span style="font-weight:600;">{{ __('admin.addon_modules.changelog') }}</span></div>
+    <div class="card-body" style="padding:16px;">
+        @foreach($changelog as $entry)
+        <div style="margin-bottom:16px;">
+            <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;">
+                <strong style="font-size:14px;">v{{ $entry['version'] ?? '' }}</strong>
+                @if(!empty($entry['date']))<span style="font-size:12px;color:var(--pn-muted);">{{ $entry['date'] }}</span>@endif
+            </div>
+            @if(!empty($entry['changes']))
+            <ul style="margin:0 0 0 20px;padding:0;font-size:13px;color:var(--pn-muted);">
+                @foreach($entry['changes'] as $change)
+                <li style="margin:2px 0;">{{ $change }}</li>
+                @endforeach
+            </ul>
+            @endif
+        </div>
+        @endforeach
+    </div>
+</div>
+@endif
+
 @endsection

--- a/resources/views/admin/ksef/index.blade.php
+++ b/resources/views/admin/ksef/index.blade.php
@@ -1,0 +1,73 @@
+@extends('admin.layouts.app')
+@section('title', __('messages.ksef.settings_title'))
+@section('content')
+<div class="page-header">
+    <h1>{{ __('messages.ksef.settings_title') }}</h1>
+</div>
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
+    <p style="font-size:13px;color:var(--pn-muted);margin:0;">{{ __('messages.ksef.addon_output_hint') }}</p>
+    <form method="POST" action="{{ route('admin.ksef.test') }}" style="margin:0;">
+        @csrf
+        <button type="submit" class="btn btn-success btn-sm" style="font-size:13px;padding:6px 14px;font-weight:600;">{{ __('messages.ksef.test') }}</button>
+    </form>
+</div>
+
+@if($records->isEmpty())
+    <p style="color:var(--pn-muted);font-size:13px;">{{ __('messages.ksef.none_yet') }}</p>
+@else
+    <div class="card">
+        <div class="card-body" style="padding:0;">
+            <table style="width:100%;font-size:13px;border-collapse:collapse;">
+                <tr>
+                    <th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.invoice') }}</th>
+                    <th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.client') }}</th>
+                    <th style="padding:8px;text-align:right;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.total') }}</th>
+                    <th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.status') }}</th>
+                    <th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.ksef_number') }}</th>
+                    <th style="padding:8px;text-align:left;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.sent_at') }}</th>
+                    <th style="padding:8px;text-align:right;color:var(--pn-muted);border-bottom:1px solid var(--border);">{{ __('messages.ksef.actions') }}</th>
+                </tr>
+                @foreach($records as $r)
+                @php
+                    $statusMap = [
+                        'pending' => ['label' => __('messages.ksef.status_pending'), 'color' => '#f59e0b'],
+                        'sent' => ['label' => __('messages.ksef.status_sent'), 'color' => '#337ab7'],
+                        'accepted' => ['label' => __('messages.ksef.status_accepted'), 'color' => '#46a546'],
+                        'rejected' => ['label' => __('messages.ksef.status_rejected'), 'color' => '#c43c35'],
+                        'error' => ['label' => __('messages.ksef.status_error'), 'color' => '#c43c35'],
+                        'corrected' => ['label' => __('messages.ksef.status_corrected'), 'color' => '#6c757d'],
+                    ];
+                    $status = $statusMap[$r->status] ?? ['label' => $r->status, 'color' => '#6c757d'];
+                @endphp
+                <tr>
+                    <td style="padding:8px;">@if($r->invoice)<a href="{{ route('admin.invoices.show', $r->invoice) }}" style="color:#337ab7;">#{{ $r->invoice->invoice_num ?? $r->invoice->id }}</a>@else&mdash;@endif</td>
+                    <td style="padding:8px;">{{ $r->invoice?->client?->display_name ?? '&mdash;' }}</td>
+                    <td style="padding:8px;text-align:right;">{{ $r->invoice ? money_fmt($r->invoice->total) : '&mdash;' }}</td>
+                    <td style="padding:8px;"><span style="display:inline-block;padding:2px 8px;border-radius:999px;background:{{ $status['color'] }}1a;color:{{ $status['color'] }};font-weight:600;font-size:12px;">{{ $status['label'] }}</span></td>
+                    <td style="padding:8px;">{{ $r->ksef_number ?? '&mdash;' }}</td>
+                    <td style="padding:8px;">{{ $r->sent_at ? $r->sent_at->format(date_fmt().' H:i') : '&mdash;' }}</td>
+                    <td style="padding:8px;text-align:right;white-space:nowrap;">
+                        @if(in_array($r->status, ['pending', 'error', 'rejected'], true))
+                        <form method="POST" action="{{ route('admin.ksef.resend', $r) }}" style="display:inline;margin:0;">
+                            @csrf
+                            <button type="submit" class="btn btn-sm btn-outline" style="font-size:12px;padding:3px 10px;">{{ __('messages.ksef.resend') }}</button>
+                        </form>
+                        @endif
+                        @if(in_array($r->status, ['sent', 'accepted'], true))
+                        <form method="POST" action="{{ route('admin.ksef.mark-corrected', $r) }}" style="display:inline;margin:0;" onsubmit="return confirm('{{ __('messages.ksef.confirm_corrected') }}');">
+                            @csrf
+                            <button type="submit" class="btn btn-sm btn-outline" style="font-size:12px;padding:3px 10px;">{{ __('messages.ksef.mark_corrected') }}</button>
+                        </form>
+                        @endif
+                    </td>
+                </tr>
+                @if($r->error_message)
+                <tr><td colspan="7" style="padding:0 8px 8px;color:#c43c35;font-size:12px;">{{ $r->error_message }}</td></tr>
+                @endif
+                @endforeach
+            </table>
+        </div>
+    </div>
+    {{ $records->links() }}
+@endif
+@endsection

--- a/resources/views/admin/ksef/index.blade.php
+++ b/resources/views/admin/ksef/index.blade.php
@@ -66,8 +66,12 @@
                 @endif
                 @endforeach
             </table>
+            @if($records->hasPages())
+            <div style="padding:10px 16px;border-top:1px solid #e5e7eb;">
+                {{ $records->withQueryString()->links() }}
+            </div>
+            @endif
         </div>
     </div>
-    {{ $records->links() }}
 @endif
 @endsection

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -103,6 +103,7 @@
                     <li><a href="{{ route('admin.payment-notifications.index') }}">{{ __('admin.nav.payment_notifications') }} @if(($sidebarCounts->pending_payment_notifications ?? 0) > 0)<span class="sb-badge sb-badge-warning">{{ $sidebarCounts->pending_payment_notifications }}</span>@endif</a></li>
                     <li><a href="{{ route('admin.config.transactions') }}">{{ __('admin.nav.transactions') }}</a></li>
                     <li><a href="{{ route('admin.config.billable-items') }}">{{ __('admin.nav.billable_items') }}</a></li>
+                    @if($ksefActive ?? false)<li><a href="{{ route('admin.ksef.index') }}">{{ __('admin.nav.ksef_status') }}</a></li>@endif
                     <li><a href="{{ route('admin.affiliates.index') }}">{{ __('admin.sidebar.affiliates') }}</a></li>
                     <li class="divider"></li>
                     <li><a href="{{ route('admin.quotes.index') }}">{{ __('admin.nav.quotes') }}</a></li>
@@ -312,7 +313,7 @@
         </ul>
 
     {{-- ── Invoices / Billing Sidebar ── --}}
-    @elseif($segment === 'invoices' || $segment === 'quotes' || $segment === 'affiliates' || $routeName === 'admin.config.transactions' || $routeName === 'admin.config.billable-items')
+    @elseif($segment === 'invoices' || $segment === 'quotes' || $segment === 'affiliates' || $segment === 'ksef' || $routeName === 'admin.config.transactions' || $routeName === 'admin.config.billable-items')
         <div class="sidebar-header"><i class="fas fa-money-bill-wave"></i> {{ __('admin.nav.billing') }}</div>
         <ul class="menu">
             <li><a href="{{ route('admin.invoices.index') }}" @if($routeName === 'admin.invoices.index' && !request()->has('status')) class="active" @endif>{{ __('admin.sidebar.all_invoices') }}</a></li>
@@ -326,6 +327,7 @@
         <ul class="menu">
             <li><a href="{{ route('admin.config.transactions') }}" @if($routeName === 'admin.config.transactions') class="active" @endif>{{ __('admin.nav.transactions') }}</a></li>
             <li><a href="{{ route('admin.config.billable-items') }}" @if($routeName === 'admin.config.billable-items') class="active" @endif>{{ __('admin.nav.billable_items') }}</a></li>
+            @if($ksefActive ?? false)<li><a href="{{ route('admin.ksef.index') }}" @if($routeName === 'admin.ksef.index') class="active" @endif>{{ __('admin.nav.ksef_status') }}</a></li>@endif
             <li><a href="{{ route('admin.affiliates.index') }}" @if($routeName === 'admin.affiliates.index') class="active" @endif>{{ __('admin.sidebar.affiliates') }}</a></li>
         </ul>
         <div class="sidebar-header"><i class="fas fa-file-signature"></i> {{ __('admin.nav.quotes') }}</div>


### PR DESCRIPTION
Przenosi status wysylek do KSeF z ekranu addonu do dedykowanej strony Rozliczenia -> KSeF status (admin/ksef/index). Nowa trasa admin.ksef.index + widok admin/ksef/index.blade.php. KsefModule::output() zostaje jako odsylacz. Pozycja menu w dropdownie Rozliczenia oraz sidebarze, widoczna tylko gdy modul KSeF wlaczony (AddonManager::isActive). Tlumaczenia EN/PL.